### PR TITLE
Feature/54 - #54 Responsive Theming for the OSB landing page

### DIFF
--- a/applications/osb-portal/src/components/App.tsx
+++ b/applications/osb-portal/src/components/App.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-router-dom";
 
 import { ThemeProvider } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
 
 import SentryErrorBoundary from "./sentry/SentryErrorBoundary";
@@ -20,7 +21,17 @@ import {
   ProtectedRoute
 } from "./index";
 
+const useStyles = makeStyles((theme) => ({
+  mainContainer: {
+    overflow: "auto",
+    minHeight: "100vh",
+    display: "flex",
+    flexDirection: "column",
+  }
+}));
+
 export const App = (props: any) => {
+  const classes = useStyles();
   React.useEffect(() => {
     props.onLoadWorkspaces();
     props.onLoadModels();
@@ -31,7 +42,7 @@ export const App = (props: any) => {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <ErrorDialog />
-        <div style={{ overflow: "hidden", height: "100vh", display: "flex", flexDirection: "column" }}>
+        <div className={classes.mainContainer}>
           <Header />
           <Router>
             <Switch>

--- a/applications/osb-portal/src/components/App.tsx
+++ b/applications/osb-portal/src/components/App.tsx
@@ -13,6 +13,10 @@ const useStyles = makeStyles(() => ({
     minHeight: "100vh",
     display: "flex",
     flexDirection: "column",
+    [theme.breakpoints.up("md")]: {
+      maxHeight: "100vh",
+      overflow: "hidden",
+    }
   },
 }));
 

--- a/applications/osb-portal/src/components/App.tsx
+++ b/applications/osb-portal/src/components/App.tsx
@@ -1,33 +1,19 @@
 import * as React from "react";
-
-import {
-  BrowserRouter as Router,
-  Route,
-  Switch
-} from "react-router-dom";
-
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { ThemeProvider } from "@material-ui/core/styles";
-import { makeStyles } from "@material-ui/core/styles";
-import CssBaseline from "@material-ui/core/CssBaseline";
-
+import { CssBaseline, makeStyles } from "@material-ui/core";
 import SentryErrorBoundary from "./sentry/SentryErrorBoundary";
-
 import HomePage from "./pages/HomePage";
 import theme from "../theme";
-import {
-  Header,
-  ErrorDialog,
-  WorkspacePage,
-  ProtectedRoute
-} from "./index";
+import { Header, ErrorDialog, WorkspacePage, ProtectedRoute } from "./index";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   mainContainer: {
     overflow: "auto",
     minHeight: "100vh",
     display: "flex",
     flexDirection: "column",
-  }
+  },
 }));
 
 export const App = (props: any) => {

--- a/applications/osb-portal/src/components/header/Banner.tsx
+++ b/applications/osb-portal/src/components/header/Banner.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundSize: "cover",
     backgroundRepeat: "no-repeat",
     backgroundPosition: "center",
-    height: "25vh",
+    height: "35vh",
   },
   mainFeaturedPostContent: {
     position: "absolute",

--- a/applications/osb-portal/src/components/header/Banner.tsx
+++ b/applications/osb-portal/src/components/header/Banner.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import Grid from "@material-ui/core/Grid";
 import Button from "@material-ui/core/Button";
 import { UserInfo } from "../../types/user";
 
@@ -13,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundSize: "cover",
     backgroundRepeat: "no-repeat",
     backgroundPosition: "center",
-    height: "25vh"
+    height: "25vh",
   },
   mainFeaturedPostContent: {
     position: "absolute",
@@ -43,20 +42,8 @@ export const Banner = (props: any) => {
       : "Let's do some science.";
 
   return (
-    <section
-      className={classes.mainFeaturedPost}
-      style={{ backgroundImage: `url(images/banner.png)` }}
-    >
-      {/* Increase the priority of the hero background image */}
-      {
-        <img
-          style={{ display: "none" }}
-          src="images/banner.png"
-          alt="Let us show you around"
-        />
-      }
-
-      <div className={classes.mainFeaturedPostContent}>
+    <Box className={classes.mainFeaturedPost}>
+      <Box className={classes.mainFeaturedPostContent}>
         <Box>
           <Typography component="h2" variant="h1" gutterBottom={true}>
             {text1}
@@ -67,13 +54,11 @@ export const Banner = (props: any) => {
           <Box display="flex" pt={1} flexDirection="row">
             <Button variant="outlined">Take the tour</Button>
             {user === null ? (
-              <Button onClick={handleSignup}>
-                Sign up
-              </Button>
+              <Button onClick={handleSignup}>Sign up</Button>
             ) : null}
           </Box>
         </Box>
-      </div>
-    </section>
+      </Box>
+    </Box>
   );
 };

--- a/applications/osb-portal/src/components/header/Header.tsx
+++ b/applications/osb-portal/src/components/header/Header.tsx
@@ -1,20 +1,17 @@
 import * as React from "react";
 
-import { makeStyles } from "@material-ui/core/styles";
 import {
   Toolbar,
   Box,
-  Typography,
   Button,
-  IconButton,
+  Paper,
+  Popper,
+  MenuItem,
+  MenuList,
+  ClickAwayListener,
+  makeStyles,
 } from "@material-ui/core";
 import PersonIcon from "@material-ui/icons/Person";
-import SearchIcon from "@material-ui/icons/Search";
-import Paper from "@material-ui/core/Paper";
-import Popper from "@material-ui/core/Popper";
-import MenuItem from "@material-ui/core/MenuItem";
-import MenuList from "@material-ui/core/MenuList";
-import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 
 const title = "Open Source Brain";
 
@@ -41,8 +38,8 @@ const useStyles = makeStyles((theme) => ({
     display: "inline-flex",
   },
   button: {
-    textTransform: 'none'
-  }
+    textTransform: "none",
+  },
 }));
 
 export const Header = (props: any) => {
@@ -70,45 +67,47 @@ export const Header = (props: any) => {
 
   const headerText =
     user === null ? (
-      <Button onClick={handleUserLogin} className={classes.button}>Sign in</Button>
+      <Button onClick={handleUserLogin} className={classes.button}>
+        Sign in
+      </Button>
     ) : (
-        <Box alignItems="center" display="flex">
-          <Popper open={Boolean(menuOpen)} anchorEl={menuAnchorRef.current}>
-            <Paper>
-              <ClickAwayListener onClickAway={handleMenuClose}>
-                <MenuList autoFocusItem={menuOpen} id="user-menu">
-                  <MenuItem>My account</MenuItem>
-                  <MenuItem>Settings</MenuItem>
-                  <MenuItem onClick={handleUserLogout}>Logout</MenuItem>
-                </MenuList>
-              </ClickAwayListener>
-            </Paper>
-          </Popper>
-          <Button
-            size="large"
-            ref={menuAnchorRef}
-            aria-controls={menuOpen ? "user-menu" : undefined}
-            aria-haspopup="true"
-            onClick={handleMenuToggle}
-            startIcon={<PersonIcon fontSize="large" />}
-            className={classes.button}
-          >
-            {user.firstname}
-          </Button>
-        </Box>
-      );
+      <Box alignItems="center" display="flex">
+        <Popper open={Boolean(menuOpen)} anchorEl={menuAnchorRef.current}>
+          <Paper>
+            <ClickAwayListener onClickAway={handleMenuClose}>
+              <MenuList autoFocusItem={menuOpen} id="user-menu">
+                <MenuItem>My account</MenuItem>
+                <MenuItem>Settings</MenuItem>
+                <MenuItem onClick={handleUserLogout}>Logout</MenuItem>
+              </MenuList>
+            </ClickAwayListener>
+          </Paper>
+        </Popper>
+        <Button
+          size="large"
+          ref={menuAnchorRef}
+          aria-controls={menuOpen ? "user-menu" : undefined}
+          aria-haspopup="true"
+          onClick={handleMenuToggle}
+          startIcon={<PersonIcon fontSize="large" />}
+          className={classes.button}
+        >
+          {user.firstname}
+        </Button>
+      </Box>
+    );
 
   const handleToggleDrawer = (e: any) => {
     if (props.drawerEnabled) {
       e.preventDefault();
       props.onToggleDrawer();
     }
-  }
+  };
 
   return (
     <React.Fragment>
       <Toolbar className={classes.toolbar}>
-        <div>
+        <Box>
           <a href="/" onClick={handleToggleDrawer}>
             <img
               src="/images/osb-logo-full.png"
@@ -117,13 +116,13 @@ export const Header = (props: any) => {
               height="25"
             />
           </a>
-        </div>
-        <div>
+        </Box>
+        <Box>
           {/* <IconButton>
               <SearchIcon />
             </IconButton> */}
           {headerText}
-        </div>
+        </Box>
       </Toolbar>
     </React.Fragment>
   );

--- a/applications/osb-portal/src/components/menu/MainMenu.tsx
+++ b/applications/osb-portal/src/components/menu/MainMenu.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import Box from "@material-ui/core/Box";
 import { MainMenuItem } from "./MainMenuItem";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   button: {
     textTransform: "inherit",
     minWidth: "auto",
@@ -21,10 +21,10 @@ export const MainMenu = () => {
   const classes = useStyles();
 
   return (
-    <Box display="flex" p={0} bgcolor="background.paper">
+    <Box display="flex" flexWrap="wrap" p={0} bgcolor="background.paper">
       <MainMenuItem
         title="OSB"
-        className={classes.button + ' ' + classes.firstButton}
+        className={classes.button + " " + classes.firstButton}
       />
       <MainMenuItem title="File" className={classes.button} />
       <MainMenuItem title="View" className={classes.button} />

--- a/applications/osb-portal/src/components/pages/HomePage.tsx
+++ b/applications/osb-portal/src/components/pages/HomePage.tsx
@@ -20,22 +20,22 @@ export default (props: any) => (
     <MainMenu />
     <Box p={1} className="verticalFit">
       <Grid container>
-        <Grid item xs={12} sm={12} md={6} container alignItems="stretch">
+        <Grid item xs={12} sm={12} md={6} container className="leftContainer">
           <Grid item={true} xs={12}>
-            <Paper style={{ overflow: "hidden", marginBottom: "10px" }} elevation={0}>
+            <Paper style={{ overflow: "hidden", marginBottom: "12px" }} elevation={0}>
               <Banner />
             </Paper>
           </Grid>
           <Grid item={true} xs={12}>
-            <Paper style={{ marginBottom: "10px" }} elevation={0}>
+            <Paper style={{ marginBottom: "12px" }} elevation={0}>
               <Box p={3}>
                 <WorkspaceToolBox />
               </Box>
             </Paper>
           </Grid>
           <Grid item={true} xs={12} className="verticalFit">
-            <Paper style={{ marginBottom: "10px" }} elevation={0}>
-              <Box p={3}>
+            <Paper style={{ marginBottom: "27px" }} elevation={0}>
+              <Box p={3} height="40vh">
                 <Latest />
               </Box>
             </Paper>

--- a/applications/osb-portal/src/components/pages/HomePage.tsx
+++ b/applications/osb-portal/src/components/pages/HomePage.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Grid, Paper } from "@material-ui/core";
 import Box from "@material-ui/core/Box";
 import MainMenu from "../menu/MainMenu";
-
+import { makeStyles } from "@material-ui/core/styles";
 import { Latest } from "../latest/Latest";
 
 import {
@@ -15,27 +15,40 @@ import {
   ErrorDialog,
 } from "..";
 
-export default (props: any) => (
-  <>
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    marginBottom: theme.spacing(2),
+    overflow: "hidden",
+  },
+  moreMargin: {
+    marginBottom: theme.spacing(4),
+  },
+}));
+
+
+export default (props: any) => {
+  const classes = useStyles();
+
+  return <>
     <MainMenu />
     <Box p={1} className="verticalFit">
       <Grid container>
         <Grid item xs={12} sm={12} md={6} container className="leftContainer">
           <Grid item={true} xs={12}>
-            <Paper style={{ overflow: "hidden", marginBottom: "12px" }} elevation={0}>
+            <Paper className={classes.paper} elevation={0}>
               <Banner />
             </Paper>
           </Grid>
           <Grid item={true} xs={12}>
-            <Paper style={{ marginBottom: "12px" }} elevation={0}>
-              <Box p={3}>
+            <Paper className={classes.paper} elevation={0}>
+              <Box p={3} >
                 <WorkspaceToolBox />
               </Box>
             </Paper>
           </Grid>
           <Grid item={true} xs={12} className="verticalFit">
-            <Paper style={{ marginBottom: "27px" }} elevation={0}>
-              <Box p={3} height="40vh">
+            <Paper className={classes.moreMargin} elevation={0}>
+              <Box p={3} height="36vh">
                 <Latest />
               </Box>
             </Paper>
@@ -49,4 +62,4 @@ export default (props: any) => (
       </Grid>
     </Box>
   </>
-);
+};

--- a/applications/osb-portal/src/components/pages/HomePage.tsx
+++ b/applications/osb-portal/src/components/pages/HomePage.tsx
@@ -32,8 +32,8 @@ export default (props: any) => {
   return <>
     <MainMenu />
     <Box p={1} className="verticalFit">
-      <Grid container>
-        <Grid item xs={12} sm={12} md={6} container className="leftContainer">
+      <Grid container={true}>
+        <Grid item={true} xs={12} sm={12} md={6} container={true} className="leftContainer">
           <Grid item={true} xs={12}>
             <Paper className={classes.paper} elevation={0}>
               <Banner />
@@ -54,7 +54,7 @@ export default (props: any) => {
             </Paper>
           </Grid>
         </Grid>
-        <Grid item xs={12} sm={12} md={6} container alignItems="stretch">
+        <Grid item={true} xs={12} sm={12} md={6} container={true} alignItems="stretch">
           <Box pl={2} width={1}>
               <Workspaces />
           </Box>

--- a/applications/osb-portal/src/components/pages/HomePage.tsx
+++ b/applications/osb-portal/src/components/pages/HomePage.tsx
@@ -19,28 +19,34 @@ export default (props: any) => (
   <>
     <MainMenu />
     <Box p={1} className="verticalFit">
-      <Grid container={true} spacing={1} alignItems="stretch">
-        <Grid item={true} xs={12}>
-          <Paper style={{ overflow: "hidden" }} elevation={0}>
-            <Banner />
-          </Paper>
+      <Grid container>
+        <Grid item xs={12} sm={12} md={6} container alignItems="stretch">
+          <Grid item={true} xs={12}>
+            <Paper style={{ overflow: "hidden", marginBottom: "10px" }} elevation={0}>
+              <Banner />
+            </Paper>
+          </Grid>
+          <Grid item={true} xs={12}>
+            <Paper style={{ marginBottom: "10px" }} elevation={0}>
+              <Box p={3}>
+                <WorkspaceToolBox />
+              </Box>
+            </Paper>
+          </Grid>
+          <Grid item={true} xs={12} className="verticalFit">
+            <Paper style={{ marginBottom: "10px" }} elevation={0}>
+              <Box p={3}>
+                <Latest />
+              </Box>
+            </Paper>
+          </Grid>
         </Grid>
-        <Grid item={true} xs={6}>
-          <Paper elevation={0}>
-            <Box p={3}>
-              <WorkspaceToolBox />
-            </Box>
-          </Paper>
-        </Grid>
-        <Grid item={true} xs={6} className="verticalFit">
-          <Paper elevation={0}>
-            <Box p={3}>
-              <Latest />
-            </Box>
-          </Paper>
+        <Grid item xs={12} sm={12} md={6} container alignItems="stretch">
+          <Box pl={2} width={1}>
+              <Workspaces />
+          </Box>
         </Grid>
       </Grid>
-      <Workspaces />
     </Box>
   </>
 );

--- a/applications/osb-portal/src/components/workspace/NewWorkspaceToolBox.tsx
+++ b/applications/osb-portal/src/components/workspace/NewWorkspaceToolBox.tsx
@@ -26,6 +26,14 @@ const useStyles = makeStyles((theme) => ({
   dialogButtons: {
     paddingRight: 0,
   },
+  cardHeading: {
+    textAlign: "center",
+    marginBottom: "20px",
+    [theme.breakpoints.up("md")]: {
+      paddingLeft: "20px",
+      textAlign: "left",
+    }
+  },
 }));
 
 
@@ -40,42 +48,46 @@ export const WorkspaceToolBox = (props: any) => {
   return (
     <>
 
-      <Typography component="h2" variant="h6" align="center" gutterBottom={true}>
-        Create a new Workspace
-      </Typography>
       <Box mt={3}>
         <Grid container={true} alignItems="center" justify="center" spacing={5}>
-          <Grid item={true}>
-            <WorkspaceItem
-              icon={Icons.CircleIcon}
-              title="Single Cell"
-              template={WorkspaceTemplateType.singleCell}
-              user={user}
-            />
+          <Grid sm={12} md={3}>
+            <Typography component="h2" variant="h6" className={classes.cardHeading}>
+              Create a new Workspace
+            </Typography>
           </Grid>
-          <Grid item={true}>
-            <WorkspaceItem
-              icon={Icons.SquareCirclesIcon}
-              title="Network"
-              template={WorkspaceTemplateType.network}
-              user={user}
-            />
-          </Grid>
-          <Grid item={true}>
-            <WorkspaceItem
-              icon={Icons.ChartIcon}
-              title="Data Analysis"
-              template={WorkspaceTemplateType.explorer}
-              user={user}
-            />
-          </Grid>
-          <Grid item={true}>
-            <WorkspaceItem
-              icon={Icons.CubeIcon}
-              title="Playground"
-              template={WorkspaceTemplateType.playground}
-              user={user}
-            />
+          <Grid xs={12} sm={12} md={9}>
+            <Grid xs={12} justify="center" item={true}>
+              <WorkspaceItem
+                icon={Icons.CircleIcon}
+                title="Single Cell"
+                template={WorkspaceTemplateType.singleCell}
+                user={user}
+              />
+            </Grid>
+            <Grid xs={12} justify="center" item={true}>
+              <WorkspaceItem
+                icon={Icons.SquareCirclesIcon}
+                title="Network"
+                template={WorkspaceTemplateType.network}
+                user={user}
+              />
+            </Grid>
+            <Grid xs={12} justify="center" item={true}>
+              <WorkspaceItem
+                icon={Icons.ChartIcon}
+                title="Data Analysis"
+                template={WorkspaceTemplateType.explorer}
+                user={user}
+              />
+            </Grid>
+            <Grid xs={12} justify="center" item={true}>
+              <WorkspaceItem
+                icon={Icons.CubeIcon}
+                title="Playground"
+                template={WorkspaceTemplateType.playground}
+                user={user}
+              />
+            </Grid>
           </Grid>
         </Grid>
       </Box>

--- a/applications/osb-portal/src/components/workspace/NewWorkspaceToolBox.tsx
+++ b/applications/osb-portal/src/components/workspace/NewWorkspaceToolBox.tsx
@@ -32,7 +32,15 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.up("md")]: {
       paddingLeft: "20px",
       textAlign: "left",
-    }
+    },
+  },
+  cardText: {
+    display: "inline-block",
+    marginRight: "5px",
+    [theme.breakpoints.up("md")]: {
+      display: "block",
+      marginRight: "0",
+    },
   },
 }));
 
@@ -50,12 +58,13 @@ export const WorkspaceToolBox = (props: any) => {
 
       <Box mt={3}>
         <Grid container={true} alignItems="center" justify="center" spacing={5}>
-          <Grid sm={12} md={3}>
+          <Grid sm={12} md={4} lg={3}>
             <Typography component="h2" variant="h6" className={classes.cardHeading}>
-              Create a new Workspace
+              <Box component="span" className={classes.cardText}>Create a</Box>
+              <Box component="span" className={classes.cardText}>new Workspace</Box>
             </Typography>
           </Grid>
-          <Grid xs={12} sm={12} md={9}>
+          <Grid xs={12} sm={12} md={8} lg={9}>
             <Grid xs={12} justify="center" item={true}>
               <WorkspaceItem
                 icon={Icons.CircleIcon}

--- a/applications/osb-portal/src/components/workspace/NewWorkspaceToolBox.tsx
+++ b/applications/osb-portal/src/components/workspace/NewWorkspaceToolBox.tsx
@@ -26,11 +26,11 @@ const useStyles = makeStyles((theme) => ({
   dialogButtons: {
     paddingRight: 0,
   },
-  cardHeading: {
+  toolBoxHeading: {
     textAlign: "center",
-    marginBottom: "20px",
+    marginBottom: theme.spacing(2),
     [theme.breakpoints.up("md")]: {
-      paddingLeft: "20px",
+      paddingLeft: theme.spacing(2),
       textAlign: "left",
     },
   },
@@ -59,7 +59,7 @@ export const WorkspaceToolBox = (props: any) => {
       <Box mt={3}>
         <Grid container={true} alignItems="center" justify="center" spacing={5}>
           <Grid sm={12} md={4} lg={3}>
-            <Typography component="h2" variant="h6" className={classes.cardHeading}>
+            <Typography component="h2" variant="h6" className={classes.toolBoxHeading}>
               <Box component="span" className={classes.cardText}>Create a</Box>
               <Box component="span" className={classes.cardText}>new Workspace</Box>
             </Typography>

--- a/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
@@ -25,25 +25,26 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: "space-between",
   },
   icon: {
-    fontSize: "0.9em",
+    fontSize: "1em",
   },
   imageIcon: {
     fontSize: "7em",
   },
   actions: {
-    display: "block",
-    textAlign: "right",
+    lineHeight: "0",
+    justifyContent: "flex-end",
   },
   imageContainer: {
-    display: "flex",
-    justifyContent: "center",
     overflow: "hidden",
-    alignItems: "center",
-    height: '130px',
+    height: "130px",
+    margin: "0 0 auto",
   },
   image: {
+    height: "100%",
     width: "100%",
-    maxWidth: "100%"
+    maxWidth: "100%",
+    objectFit: "cover",
+    minHeight: "130px",
   },
   ellipses: {
     overflow: "hidden",
@@ -51,6 +52,12 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: "nowrap",
     width: "100%",
     display: "block",
+  },
+  link: {
+    lineHeight: "0",
+    display: "inline-block",
+    width: "100%",
+    textAlign: "center",
   },
 }));
 
@@ -64,8 +71,17 @@ export const WorkspaceCard = (props: Props) => {
         <Icons.InfoIcon className={classes.icon} />
       </CardActions>
 
-      <Box className={classes.imageContainer}>
-        <Link href={`/workspace/${workspace.id}`} color="inherit">
+      <Box
+        className={classes.imageContainer}
+        justifyContent="center"
+        alignItems="center"
+        display="flex"
+      >
+        <Link
+          href={`/workspace/${workspace.id}`}
+          color="inherit"
+          className={classes.link}
+        >
           {!workspace.thumbnail ? (
             <FolderIcon className={classes.imageIcon} />
           ) : (
@@ -80,7 +96,11 @@ export const WorkspaceCard = (props: Props) => {
       </Box>
 
       <CardContent>
-        <Link href={`/workspace/${workspace.id}`} color="inherit" title={`${workspace.name}`}>
+        <Link
+          href={`/workspace/${workspace.id}`}
+          color="inherit"
+          title={`${workspace.name}`}
+        >
           <Typography component="h2" variant="h5" className={classes.ellipses}>
             {workspace.name}
           </Typography>

--- a/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
@@ -45,6 +45,13 @@ const useStyles = makeStyles((theme) => ({
     width: "100%",
     maxWidth: "100%"
   },
+  ellipses: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    width: "100%",
+    display: "block",
+  },
 }));
 
 export const WorkspaceCard = (props: Props) => {
@@ -73,12 +80,12 @@ export const WorkspaceCard = (props: Props) => {
       </Box>
 
       <CardContent>
-        <Link href={`/workspace/${workspace.id}`} color="inherit">
-          <Typography component="h2" variant="h5">
+        <Link href={`/workspace/${workspace.id}`} color="inherit" title={`${workspace.name}`}>
+          <Typography component="h2" variant="h5" className={classes.ellipses}>
             {workspace.name}
           </Typography>
         </Link>
-        <Typography variant="caption">
+        <Typography variant="caption" className={classes.ellipses}>
           {workspace.lastOpen.type.application.name},{" "}
           {formatDate(workspace.timestampUpdated)}
         </Typography>

--- a/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "0.9em",
   },
   imageIcon: {
-    fontSize: "8em",
+    fontSize: "7em",
   },
   actions: {
     display: "block",
@@ -38,9 +38,12 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     justifyContent: "center",
     overflow: "hidden",
+    alignItems: "center",
+    height: '130px',
   },
   image: {
     width: "100%",
+    maxWidth: "100%"
   },
 }));
 

--- a/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
+import Box from "@material-ui/core/Box";
 import Link from "@material-ui/core/Link";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
@@ -36,12 +37,11 @@ const useStyles = makeStyles((theme) => ({
   imageContainer: {
     display: "flex",
     justifyContent: "center",
-    height: 150,
-    overflow: "hidden"
+    overflow: "hidden",
   },
   image: {
-    width: "100%"
-  }
+    width: "100%",
+  },
 }));
 
 export const WorkspaceCard = (props: Props) => {
@@ -54,25 +54,30 @@ export const WorkspaceCard = (props: Props) => {
         <Icons.InfoIcon className={classes.icon} />
       </CardActions>
 
-      <div className={classes.imageContainer}>
+      <Box className={classes.imageContainer}>
         <Link href={`/workspace/${workspace.id}`} color="inherit">
           {!workspace.thumbnail ? (
             <FolderIcon className={classes.imageIcon} />
           ) : (
-              <img src={workspace.thumbnail} className={classes.image} title={openTitle} alt={openTitle} />
-            )}
+            <img
+              src={workspace.thumbnail}
+              className={classes.image}
+              title={openTitle}
+              alt={openTitle}
+            />
+          )}
         </Link>
-      </div>
+      </Box>
 
       <CardContent>
-
         <Link href={`/workspace/${workspace.id}`} color="inherit">
           <Typography component="h2" variant="h5">
             {workspace.name}
           </Typography>
         </Link>
         <Typography variant="caption">
-          {workspace.lastOpen.type.application.name}, {formatDate(workspace.timestampUpdated)}
+          {workspace.lastOpen.type.application.name},{" "}
+          {formatDate(workspace.timestampUpdated)}
         </Typography>
       </CardContent>
     </Card>

--- a/applications/osb-portal/src/components/workspace/Workspaces.tsx
+++ b/applications/osb-portal/src/components/workspace/Workspaces.tsx
@@ -15,7 +15,7 @@ export const Workspaces = (props: any) => {
     workspaces
       ? workspaces.map((workspace: Workspace, index: number) => {
         return (
-          <Grid item={true} key={index} xs={6} sm={3} md={6} lg={3} >
+          <Grid item={true} key={index} xs={6} sm={4} md={6} lg={4} xl={3} >
             <WorkspaceCard workspace={workspace} />
           </Grid>
         );
@@ -48,7 +48,7 @@ export const Workspaces = (props: any) => {
           {workspaceList.length} Workspaces
         </Typography>
       </Box>
-      <Box className="verticalFit">
+      <Box className="verticalFit card-container">
         <Box pt={1} pb={1} className="scrollbar">
           <Grid container={true} spacing={1}>
             {workspaceList}

--- a/applications/osb-portal/src/components/workspace/Workspaces.tsx
+++ b/applications/osb-portal/src/components/workspace/Workspaces.tsx
@@ -15,7 +15,7 @@ export const Workspaces = (props: any) => {
     workspaces
       ? workspaces.map((workspace: Workspace, index: number) => {
         return (
-          <Grid item={true} key={index} xs={6} sm={4} md={3} lg={2} xl={1}>
+          <Grid item={true} key={index} xs={6} sm={3} md={6} lg={3} >
             <WorkspaceCard workspace={workspace} />
           </Grid>
         );
@@ -33,7 +33,7 @@ export const Workspaces = (props: any) => {
 
   return (
     <React.Fragment>
-      <Box mt={3} mb={2}>
+      <Box mb={2}>
         <Tabs
           value={value}
           textColor="primary"
@@ -48,13 +48,13 @@ export const Workspaces = (props: any) => {
           {workspaceList.length} Workspaces
         </Typography>
       </Box>
-      <div className="verticalFit">
+      <Box className="verticalFit">
         <Box pt={1} pb={1} className="scrollbar">
           <Grid container={true} spacing={1}>
             {workspaceList}
           </Grid>
         </Box>
-      </div>
+      </Box>
     </React.Fragment>
   );
 };

--- a/applications/osb-portal/src/css/main.less
+++ b/applications/osb-portal/src/css/main.less
@@ -1,6 +1,10 @@
 @import (css) url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;1,300;1,400&display=swap");
 @import "variables";
 
+.leftContainer {
+  align-items: flex-start;
+  height: 50% !important;
+}
 .verticalFit {
     overflow: hidden;
     flex: 1;
@@ -8,6 +12,12 @@
     flex-direction: column;
     align-items: stretch;
     min-width: 100%;
+    &.card-container{
+      @media screen and (min-width:960px){
+        max-height: calc(100vh - 80px);
+        padding-bottom: 8vh;
+      }
+    }
 }
 
 .scrollbarStyle {

--- a/applications/osb-portal/src/css/main.less
+++ b/applications/osb-portal/src/css/main.less
@@ -7,6 +7,7 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    min-width: 100%;
 }
 
 .scrollbarStyle {

--- a/applications/osb-portal/src/theme.js
+++ b/applications/osb-portal/src/theme.js
@@ -112,7 +112,14 @@ const theme = {
     },
     MuiCard: { root: { flex: 1 } },
     MuiBottomNavigation: { root: { backgroundColor: bgRegular, marginBottom: 8, borderRadius: 4 } },
-    MuiPaper: { root: { color: 'inherit', backgroundColor: bgRegular, flex: 1 } },
+    MuiPaper: {
+      root: {
+        color: 'inherit', backgroundColor: bgRegular, flex: 1
+      },
+      rounded: {
+        borderRadius: '5px'
+      },
+    },
     MuiBottomNavigationAction: { 
       root: { color: fontColor, textTransform: 'uppercase' },
       label: { fontSize: "0.65rem", "&.Mui-selected": { fontSize: "0.65rem" } },
@@ -170,12 +177,33 @@ const theme = {
         }
       }
      },
+    MuiTabs: {
+      root: {
+        minHeight: '20px',
+        height: '20px',
+      },
+      indicator: {
+        backgroundColor: 'transparent',
+      }
+    },
     MuiTab: {
       root: {
         textTransform: 'none',
         fontSize: '1.1rem',
         fontWeight: 400,
-        paddingBottom: 0
+        padding: '0 8px 0 0',
+        textDecoration: 'none',
+        border: 0,
+        minHeight: '20px',
+        height: '20px',
+        minWidth: '150px !important',
+        textAlign: 'left',
+        '&:first-child': {
+          borderRight: '1px solid #FFF',
+        },
+        '&:last-child': {
+          padding: '0 0 0 8px',
+        }
       }
     },
     MuiToolbar: {


### PR DESCRIPTION
Please Note: 
- Workspace title and info text line have overflow ellipsis, can be removed if complete name is to be shown ( long title were coming in several lines)
- Font size is not according to Figma.
- Kept Equidistant spacing between Header options like OSB, File etc. (figma as different spacing)
- Rest everything is according to the designs - Left Panel, Right Panel, Scroller, overall styling and layout fixes for both
- Replaces html elements with Material UI elements

Please let me know if I missed something @filippomc @tarelli 
