### PR TITLE
#74 chore: store each workspace resource in a seperate folder, where folder is the name of the resource

### DIFF
--- a/applications/osb-portal/src/apiclient/workspaces/models/WorkspaceResource.ts
+++ b/applications/osb-portal/src/apiclient/workspaces/models/WorkspaceResource.ts
@@ -43,11 +43,17 @@ export interface WorkspaceResource {
      */
     name: string;
     /**
-     * WorkspaceResource location where the resource is stored
+     * WorkspaceResource WorkspaceResource location original location of the resource
      * @type {string}
      * @memberof WorkspaceResource
      */
     location: string;
+    /**
+     * WorkspaceResource WorkspaceResource folder where the resource will stored in the pvc
+     * @type {string}
+     * @memberof WorkspaceResource
+     */
+    folder?: string;
     /**
      * 
      * @type {ResourceStatus}
@@ -99,6 +105,7 @@ export function WorkspaceResourceFromJSONTyped(json: any, ignoreDiscriminator: b
         'id': !exists(json, 'id') ? undefined : json['id'],
         'name': json['name'],
         'location': json['location'],
+        'folder': json['folder'],
         'status': !exists(json, 'status') ? undefined : ResourceStatusFromJSON(json['status']),
         'timestampCreated': !exists(json, 'timestamp_created') ? undefined : (new Date(json['timestamp_created'])),
         'timestampUpdated': !exists(json, 'timestamp_updated') ? undefined : (new Date(json['timestamp_updated'])),
@@ -120,6 +127,7 @@ export function WorkspaceResourceToJSON(value?: WorkspaceResource | null): any {
         'id': value.id,
         'name': value.name,
         'location': value.location,
+        'folder': value.folder,
         'status': ResourceStatusToJSON(value.status),
         'timestamp_created': value.timestampCreated === undefined ? undefined : (value.timestampCreated.toISOString()),
         'timestamp_updated': value.timestampUpdated === undefined ? undefined : (value.timestampUpdated.toISOString()),

--- a/applications/osb-portal/src/components/workspace/drawer/WorkspaceResourceBrowser.tsx
+++ b/applications/osb-portal/src/components/workspace/drawer/WorkspaceResourceBrowser.tsx
@@ -17,7 +17,7 @@ import {
 import { ActionLineWeight } from "material-ui/svg-icons";
 
 const openFileResource = (resource: WorkspaceResource, refreshWorkspace: any) => (e: any) => {
-  const fileName = resource.location.slice(resource.location.lastIndexOf("/") + 1);
+  const fileName = resource.folder + "/" + resource.location.slice(resource.location.lastIndexOf("/") + 1);
   const r = WorkspaceResourceService.workspacesControllerWorkspaceResourceOpen(resource.id).then(() => {
     const iFrame: HTMLIFrameElement = document.getElementById("workspace-frame") as HTMLIFrameElement;
     iFrame.contentWindow.postMessage(fileName, '*');

--- a/applications/osb-portal/src/types/workspace.ts
+++ b/applications/osb-portal/src/types/workspace.ts
@@ -18,6 +18,7 @@ export interface WorkspaceResource {
     id?: number,
     name: string,
     location: string,
+    folder?: string,
     type: ResourceType,
     status?: ResourceStatus
 }

--- a/applications/workspaces/api/openapi.yaml
+++ b/applications/workspaces/api/openapi.yaml
@@ -989,9 +989,13 @@ components:
           type: string
           example: Workspace Resource One
         location:
-          description: WorkspaceResource location where the resource is stored
+          description: WorkspaceResource location original location of the resource
           type: string
           example: https://github.com/OpenSourceBrain/NWBShowcase/raw/master/NWB/time_series_data.nwb  
+        folder:
+          description: WorkspaceResource folder where the resource will stored in the pvc
+          type: string
+          example: Workspace Resource One
         status:
           description: WorkspaceResource status is the resource
           $ref: "#/components/schemas/ResourceStatus"

--- a/applications/workspaces/server/workspaces/openapi/openapi.yaml
+++ b/applications/workspaces/server/workspaces/openapi/openapi.yaml
@@ -986,9 +986,13 @@ components:
           type: string
           example: Workspace Resource One
         location:
-          description: WorkspaceResource location where the resource is stored
+          description: WorkspaceResource location original location of the resource
           type: string
           example: https://github.com/OpenSourceBrain/NWBShowcase/raw/master/NWB/time_series_data.nwb
+        folder:
+          description: WorkspaceResource folder where the resource will stored in the pvc
+          type: string
+          example: Workspace Resource One
         status:
           description: WorkspaceResource status is the resource
           $ref: "#/components/schemas/ResourceStatus"

--- a/applications/workspaces/server/workspaces/repository/model_repository.py
+++ b/applications/workspaces/server/workspaces/repository/model_repository.py
@@ -107,12 +107,16 @@ class WorkspaceResourceRepository(BaseModelRepository):
         if workspace_resource.location[-3:] == "nwb":
             logger.debug(f'Pre Commit for workspace resource id: {workspace_resource.id} setting type to e')
             workspace_resource.resource_type = "e"
+        if workspace_resource.folder is None or len(workspace_resource.folder) == 0:
+            workspace_resource.folder = workspace_resource.name
         return workspace_resource
 
     def post_commit(self, workspace_resource):
         # Create a load WorkspaceResource workflow task
         logger.debug(f'Post Commit for workspace resource id: {workspace_resource.id}')
         workspace, found = WorkspaceRepository().get(id=workspace_resource.workspace_id)
+        if workspace_resource.folder is None or len(workspace_resource.folder) == 0:
+            workspace_resource.folder = workspace_resource.name
         if found:
             from ..service.workflow import create_operation
             create_operation(workspace, workspace_resource)

--- a/applications/workspaces/server/workspaces/service/workflow.py
+++ b/applications/workspaces/server/workspaces/service/workflow.py
@@ -23,11 +23,13 @@ def create_operation(workspace, workspace_resource):
     download_task = tasks.CustomTask(name='osb-download-file',
                                      image_name='workflows-extract-download',
                                      url=workspace_resource.location,
-                                     shared_directory=shared_directory)
+                                     shared_directory=shared_directory,
+                                     folder=workspace_resource.folder)
 
     op = operations.PipelineOperation(basename=f'osb-download-file-job',
                                       tasks=(download_task,),
                                       shared_directory=shared_directory,
+                                      folder=workspace_resource.folder,
                                       shared_volume_size=100,
                                       on_exit_notify={'queue':'osb-download-file-queue','payload':str(workspace_resource.id)}
                                      )


### PR DESCRIPTION
remark: renaming the workspace resource name doesn not change the folder name
added folder to the openapi model to support workspace resource name renaming