### PR TITLE
Remove extra breadcrumb separator in workspace dialog

### DIFF
--- a/applications/osb-portal/src/components/repository/RepositoryResourceBrowser.tsx
+++ b/applications/osb-portal/src/components/repository/RepositoryResourceBrowser.tsx
@@ -25,7 +25,6 @@ import {
   linkColor,
   bgLightest,
   fontColor,
-  bgDarkest,
   checkBoxColor,
   paragraph,
   bgLightestShade,
@@ -123,10 +122,6 @@ const useStyles = makeStyles((theme) => ({
         backgroundColor: bgLightest,
       },
     },
-
-
-
-
   },
   breadcrumbs: {
 
@@ -159,9 +154,7 @@ const useStyles = makeStyles((theme) => ({
         cursor: "pointer",
       },
     },
-  }
-
-
+  },
 }));
 
 export default ({ repository, checkedChanged, backAction, refresh }: { repository: OSBRepository, checkedChanged: (checked: RepositoryResourceNode[]) => any, backAction?: () => void, refresh?: boolean }) => {
@@ -191,27 +184,29 @@ export default ({ repository, checkedChanged, backAction, refresh }: { repositor
 
 
   return <>
-
-    <Breadcrumbs
-      separator={<Avatar src="/images/separator.svg" />}
-      aria-label="breadcrumb"
-      className={classes.breadcrumbs}
-    >
-      {backAction && <IconButton onClick={() => backAction()}>
-        <ArrowBackIosIcon fontSize="small" />
-      </IconButton>}
-      {
-        currentPath.map((element, i) =>
-          <Link
-            key={element.resource.name}
-            color="inherit"
-            onClick={() => setCurrentPath(currentPath.slice(0, i + 1))}
-          >
-            {i > 0 ? element.resource.name : repository.name}
-          </Link>)
+    <Box display="flex" flex-direction="row" alignItems="center">
+      {backAction &&
+        <IconButton onClick={() => backAction()}>
+          <ArrowBackIosIcon fontSize="small" />
+        </IconButton>
       }
-
-    </Breadcrumbs>
+      <Breadcrumbs
+        separator={<Avatar src="/images/separator.svg" />}
+        aria-label="breadcrumb"
+        className={classes.breadcrumbs}
+      >
+        {
+          currentPath.map((element, i) =>
+            <Link
+              key={element.resource.name}
+              color="inherit"
+              onClick={() => setCurrentPath(currentPath.slice(0, i + 1))}
+            >
+              {i > 0 ? element.resource.name : repository.name}
+            </Link>)
+        }
+      </Breadcrumbs>
+    </Box>
     <TextField
       id="standard-start-adornment"
       fullWidth={true}

--- a/applications/osb-portal/src/components/workspace/AddResourceForm.tsx
+++ b/applications/osb-portal/src/components/workspace/AddResourceForm.tsx
@@ -206,20 +206,6 @@ const useStyles = makeStyles((theme) => ({
         marginLeft: '2%',
         padding: '0.6rem',
       },
-      "& .MuiBreadcrumbs-root": {
-        paddingTop: theme.spacing(1),
-        paddingBottom: theme.spacing(0),
-        "& .MuiBreadcrumbs-ol": {
-          lineHeight: 1,
-          "& .MuiBreadcrumbs-li": {
-            "& .MuiLink-root": {
-              fontSize: '0.8rem',
-              color: fontColor,
-              cursor: 'pointer',
-            },
-          },
-        },
-      },
     },
   },
 }));


### PR DESCRIPTION
In the workspace page, when adding a resource from an OSB repository, an extra breadcrumb separator would appear in the path after the back button.