### PR TITLE
#211 allow github images with relative paths

### DIFF
--- a/applications/osb-portal/src/components/common/MarkdownViewer.tsx
+++ b/applications/osb-portal/src/components/common/MarkdownViewer.tsx
@@ -15,6 +15,7 @@ import {
   bgInputs,
   radius,
 } from "../../theme";
+import { OSBRepository } from "../../apiclient/workspaces";
 
 
 const useStyles = makeStyles((theme) => ({
@@ -121,19 +122,41 @@ const useStyles = makeStyles((theme) => ({
 
 
 
-export const MarkdownViewer = ({ text }: { text: string }) => {
-
-
-
+export const MarkdownViewer = ({ text, repository }: { text: string, repository?: OSBRepository }) => {
   const classes = useStyles();
 
+  const getImages = (str: string) => {
+    const imgRex = /<img.*?src="(.*?)"[^>]+>/g;
+    const imageTags: string[] = []
+    const imagePaths: string[] = [];
+    let img;
+    while ((img = imgRex.exec(str))) {
+      if (!img[1].startsWith('http')){
+        imageTags.push(img[0]);
+        imagePaths.push(img[1]);
+      }
+    }
+    return [imageTags, imagePaths];
+  }
 
 
+  const convertImgInMarkdown = (markDown: string) => {
+    let mark = markDown;
+    const [imageTags, imagePaths] = getImages(markDown);
+    const updatedImages : string[] = [];
+    imageTags.map((tag, index) => {
+      mark = mark.replace(tag, `[![img](${repository.uri.replace('https://github.com/', 'https://raw.githubusercontent.com/') + '/' + repository.defaultContext + '/' + imagePaths[index]})](${repository.uri.replace('https://github.com/', 'https://raw.githubusercontent.com/') + '/' + repository.defaultContext + '/' + imagePaths[index]})`)
+    })
+    for (let i = 0; i < updatedImages.length; i++) {
+      mark = mark.replace(imageTags[i], updatedImages[i]);
+    }
+    return mark;
+  };
 
   return (
     <Paper className={`verticalFit ${classes.root}`}>
-      <ReactMarkdown skipHtml={true} className="preview-box scrollbar">
-        {text}
+      <ReactMarkdown skipHtml={false} className="preview-box scrollbar">
+        {typeof repository !== 'undefined' && repository.repositoryType === 'github' ? convertImgInMarkdown(text) : text}
       </ReactMarkdown>
     </Paper>
 

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -290,7 +290,7 @@ export const RepositoryPage = (props: any) => {
                       Overview
                     </Typography>
                   </Box>
-                  <MarkdownViewer text={repository.description} />
+                  <MarkdownViewer text={repository.description} repository={repository}/>
                 </Box>
               </Grid>
               <Grid item={true} xs={12} md={6} className="verticalFill">


### PR DESCRIPTION
This commit allows GitHub images with relative paths to be displayed in the repository overview by converting an image html tag to a markdown image tag.