### PR TITLE
Minor tweaks to jupyterlab dockerfile

### DIFF
--- a/applications/jupyterlab/Dockerfile
+++ b/applications/jupyterlab/Dockerfile
@@ -3,7 +3,6 @@ USER root
 
 
 RUN apt-get update
-RUN apt-get install python-lxml -y
 RUN apt-get install graphviz -y
 RUN apt-get install openjdk-11-jdk -y
 

--- a/applications/jupyterlab/Dockerfile
+++ b/applications/jupyterlab/Dockerfile
@@ -31,7 +31,7 @@ RUN cd netpyne ; python setup.py install; cd -
 
 ####  Other simulators
 
-RUN pip install brian2 --no-cache-dir
+RUN pip install brian2 brian2tools --no-cache-dir
 
 
 ####  NWB

--- a/applications/jupyterlab/Dockerfile
+++ b/applications/jupyterlab/Dockerfile
@@ -25,7 +25,7 @@ RUN pip install neuron --no-cache-dir
 # Install specific version of NetPyNE
 ENV NETPYNE_CORE_REPO=https://github.com/Neurosim-lab/netpyne
 ENV NETPYNE_CORE_BRANCH_TAG=osbv2
-RUN git clone $NETPYNE_CORE_REPO -b $NETPYNE_CORE_BRANCH_TAG
+RUN git clone --depth=1 $NETPYNE_CORE_REPO -b $NETPYNE_CORE_BRANCH_TAG
 RUN cd netpyne ; python setup.py install; cd -
 
 

--- a/applications/jupyterlab/Dockerfile
+++ b/applications/jupyterlab/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 RUN apt-get update
 RUN apt-get install graphviz -y
-RUN apt-get install openjdk-11-jdk -y
+RUN apt-get install openjdk-11-jre-headless -y
 
 RUN apt-get install git vim htop -y      # git and general utilities
 RUN apt-get install make cmake libncurses-dev g++ -y  # make etc. to allow NEURON's nrnivmodl


### PR DESCRIPTION
- adds brian2tools (needed by brian tutorial)
- uses shallow netpyne clone (can we not use `pip install git+https...` here also @pgleeson ?)

PS: not sure if this is the right base branch to open against, but should be easily rebased to development/master.