### PR TITLE
fix(workspace-page): prevent image from being cut

### DIFF
--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -133,12 +133,10 @@ const useStyles = makeStyles((theme: any) => ({
   imageBox: {
     width: '100%',
     maxHeight: 300,
-    overflow: "hidden",
     "& img": {
+      height: 300,
       width: "100%",
-      position: "relative",
-      top: "50%",
-      transform: "translateY(-50%)"
+      objectFit: "contain",
     }
   }
 }));


### PR DESCRIPTION
fits the image in the available space

Looks like this now:

![osb-allen](https://user-images.githubusercontent.com/102575/150545482-5f8ebc0e-9c1f-45f2-81e9-9704a59ded61.png)
![osb-brian](https://user-images.githubusercontent.com/102575/150545487-77930818-ffec-49bd-ad18-52cb27fe1561.png)
![osb-dandi](https://user-images.githubusercontent.com/102575/150545489-44435779-5913-46b9-b37a-6a7795da35c8.png)
