### PR TITLE
fix(new-workspace-editor): make cancel button functional

### DIFF
--- a/applications/osb-portal/src/components/workspace/NewWorkspaceItem.tsx
+++ b/applications/osb-portal/src/components/workspace/NewWorkspaceItem.tsx
@@ -149,7 +149,7 @@ export const NewWorkspaceItem = (props: ItemProps) => {
           closeAction={() => setNewWorkspaceOpen(false)}
           maxWidth="md"
         > {defaultWorkspace ?
-          <WorkspaceEditor workspace={defaultWorkspace} onLoadWorkspace={onWorkspaceCreated} /> :
+          <WorkspaceEditor workspace={defaultWorkspace} onLoadWorkspace={onWorkspaceCreated} closeHandler={() => setNewWorkspaceOpen(false)}/> :
           <WorkspaceFromRepository close={() => setNewWorkspaceOpen(false)} workspaceCreatedCallback={onWorkspaceCreated} />
           }
 


### PR DESCRIPTION
Clicking the cancel button didn't do anything, we hadn't made it do
anything yet. So just do that.