### PR TITLE
fix: show all tags in filter

### DIFF
--- a/applications/osb-portal/src/service/RepositoryService.tsx
+++ b/applications/osb-portal/src/service/RepositoryService.tsx
@@ -92,6 +92,10 @@ class RepositoryService {
   }
 
   async getAllTags(page?: number, perPage?: number, q?: string): Promise<InlineResponse2003> {
+    if ((page === undefined) && (perPage === undefined)) {
+      page = 1;
+      perPage = 9999;
+    }
     const requestParameters = { page, perPage, q };
     return this.workspacesApi.tagGet(requestParameters);
   }


### PR DESCRIPTION
By default, the API result is paginated, with only the first 20 results
returned as the first page. Here, we request a large number of tags in
the first page to get all tags, if no request parameters have been
provided.

Fixes #339



---

An alternative is to not change the defaults like this, and explicitly change the one call to getAllTags. 