### PR TITLE
repository-filter: track currently selected filter tags, implement infinite scroll

### DIFF
--- a/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
@@ -201,6 +201,7 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
             >
               <Typography component="label" className={classes.label}>Tags</Typography>
               <Autocomplete
+                value={searchFilterValues.tags}
                 multiple={true}
                 options={searchTagOptions}
                 freeSolo={true}

--- a/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
@@ -50,6 +50,8 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
   });
 
   const [searchTagOptions, setSearchTagOptions] = useState([]);
+  const [tagPage, setTagPage] = React.useState(1);
+  const [totalTagPages, setTotalTagPages] = React.useState(0);
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const openDialog = () => setDialogOpen(true);
@@ -133,6 +135,8 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
         return tagObject.tag;
       });
       setSearchTagOptions(tags.sort((a: string, b: string) => a.localeCompare(b)));
+      setTagPage(tagsInformation.pagination.currentPage);
+      setTotalTagPages(tagsInformation.pagination.numberOfPages);
     });
   }, [])
 
@@ -222,6 +226,24 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
                 renderInput={(params) => (
                   <><SearchIcon /><TextField InputProps={{ startAdornment: (<InputAdornment position="start"><SearchIcon /></InputAdornment>) }} fullWidth={true} {...params} variant="filled" /></>
                 )}
+                ListboxProps={{
+                  onScroll: (event: React.SyntheticEvent) => {
+                    const listboxNode = event.currentTarget;
+                    if (listboxNode.scrollTop + listboxNode.clientHeight === listboxNode.scrollHeight) {
+
+                      if (tagPage < totalTagPages){
+                        RepositoryService.getAllTags(tagPage + 1, undefined, undefined).then((tagsInformation) => {
+                          const tags: any[] = tagsInformation.tags.map(tagObject => {
+                            return tagObject.tag;
+                          });
+                          setTagPage(tagsInformation.pagination.currentPage);
+                          setTotalTagPages(tagsInformation.pagination.numberOfPages);
+                          setSearchTagOptions(searchTagOptions.concat(tags.sort((a: string, b: string) => a.localeCompare(b))));
+                        });
+                      }
+                    }
+                  }
+                }}
               />
               <FormControl component="fieldset" >
                 <FormGroup>

--- a/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
@@ -52,6 +52,7 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
   const [searchTagOptions, setSearchTagOptions] = useState([]);
   const [tagPage, setTagPage] = React.useState(1);
   const [totalTagPages, setTotalTagPages] = React.useState(0);
+  const [tagSearchValue, setTagSearchValue] = React.useState("");
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const openDialog = () => setDialogOpen(true);
@@ -210,10 +211,13 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
                 options={searchTagOptions}
                 freeSolo={true}
                 onInputChange={(event, value) => {
-                  RepositoryService.getAllTags(undefined, undefined, "tag__like=" + value.toString()).then((tagsInformation) => {
+                  setTagSearchValue(value);
+                  RepositoryService.getAllTags(1, undefined, "tag__like=" + value.toString()).then((tagsInformation) => {
                     const tags = tagsInformation.tags.map(tagObject => {
                       return tagObject.tag;
                     });
+                    setTagPage(tagsInformation.pagination.currentPage);
+                    setTotalTagPages(tagsInformation.pagination.numberOfPages);
                     setSearchTagOptions(tags.sort((a: string, b: string) => a.localeCompare(b)));
                   });
                 }}
@@ -232,7 +236,11 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
                     if (listboxNode.scrollTop + listboxNode.clientHeight === listboxNode.scrollHeight) {
 
                       if (tagPage < totalTagPages){
-                        RepositoryService.getAllTags(tagPage + 1, undefined, undefined).then((tagsInformation) => {
+                        let query: any;
+                        if (tagSearchValue !== "") {
+                          query = "tag__like=" + tagSearchValue.toString();
+                        }
+                        RepositoryService.getAllTags(tagPage + 1, undefined, query).then((tagsInformation) => {
                           const tags: any[] = tagsInformation.tags.map(tagObject => {
                             return tagObject.tag;
                           });

--- a/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
@@ -170,7 +170,6 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
       setTagSearchValue(value);
       setTagPage(tagsInformation.pagination.currentPage);
       setTotalTagPages(tagsInformation.pagination.numberOfPages);
-      setSearchTagOptions(tags.sort((a: string, b: string) => a.localeCompare(b)));
       if (tagpage !== undefined) {
         setSearchTagOptions(searchTagOptions.concat(tags.sort((a: string, b: string) => a.localeCompare(b))));
       }


### PR DESCRIPTION
This ensures that after a user has selected some tags, and closed the
filter pop-up, when they re-open the filter pop-up, the selected tags
are still shown there. All we needed to do was set the value of the
pop-up so that it remembered what had been set.

Fixes #340