### PR TITLE
Tweaks to the repository page: tooltip, text tweak

### DIFF
--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -409,7 +409,7 @@ export const RepositoryPage = (props: any) => {
               <Grid item={true} xs={12} md={6} className="verticalFill">
                 <Box className={`verticalFit ${classes.repositoryResourceBrowserBox}`}>
                   <Typography component="h2" variant="h2">
-                    Resources
+                    Repository contents
                   </Typography>
                   <Box className="verticalFit">
                     <RepositoryResourceBrowser repository={repository} checkedChanged={setCheckedChips} refresh={refresh} />

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -325,13 +325,11 @@ export const RepositoryPage = (props: any) => {
             <Grid container={true} spacing={5} className="verticalFill">
               <Grid item={true} xs={12} md={6} className="verticalFill">
                 <Box className="flex-grow-1 scrollbar" maxWidth="100%" position="relative">
-                  <Box>
-
-
+                  <Box display="flex" alignItems="center" justifyContent="space-between">
                     <Typography component="h2" variant="h2" className="primary-heading">
                       Overview <Tooltip title={`Repositories provide views of files in public resources that have been indexed in OSBv2 by users. Use the Repository Contents pane on the right to select files from this repository to add to your workspaces.`}>
                         <InfoOutlinedIcon className={classes.infoIcon}/>
-                    </Tooltip>
+                      </Tooltip>
 
                     </Typography>
                   </Box>
@@ -418,11 +416,13 @@ export const RepositoryPage = (props: any) => {
               </Grid>
               <Grid item={true} xs={12} md={6} className="verticalFill">
                 <Box className={`verticalFit ${classes.repositoryResourceBrowserBox}`}>
-                  <Typography component="h2" variant="h2">
-                    Repository contents <Tooltip title={`The file list below shows the latest (current) version and contents of the repository. Select files and folders below to add to your workspaces. To see the previous version and contents of the repository, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
-                      <InfoOutlinedIcon className={classes.infoIcon}/>
-                    </Tooltip>
-                  </Typography>
+                  <Box display="flex" alignItems="center" justifyContent="space-between">
+                    <Typography component="h2" variant="h2">
+                      Repository contents <Tooltip title={`The file list below shows the latest (current) version and contents of the repository. Select files and folders below to add to your workspaces. To see the previous version and contents of the repository, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
+                        <InfoOutlinedIcon className={classes.infoIcon}/>
+                      </Tooltip>
+                    </Typography>
+                  </Box>
                   <Box className="verticalFit">
                     <RepositoryResourceBrowser repository={repository} checkedChanged={setCheckedChips} refresh={refresh} />
                   </Box>

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -324,7 +324,7 @@ export const RepositoryPage = (props: any) => {
 
 
                     <Typography component="h2" variant="h2" className="primary-heading">
-                      Overview <Tooltip title={`The repository overview page always shows the latest (current) version and contents of the repository. To see its previous version and contents, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
+                      Overview <Tooltip title={`Repositories provide views of files in public resources that have been indexed in OSBv2 by users. Use the Repository Contents pane on the right to select files from this repository to add to your workspaces.`}>
                       <InfoOutlinedIcon fontSize="small"/>
                     </Tooltip>
 
@@ -414,7 +414,9 @@ export const RepositoryPage = (props: any) => {
               <Grid item={true} xs={12} md={6} className="verticalFill">
                 <Box className={`verticalFit ${classes.repositoryResourceBrowserBox}`}>
                   <Typography component="h2" variant="h2">
-                    Repository contents
+                    Repository contents <Tooltip title={`The file list below shows the latest (current) version and contents of the repository. Select files and folders below to add to your workspaces. To see the previous version and contents of the repository, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
+                      <InfoOutlinedIcon fontSize="small"/>
+                    </Tooltip>
                   </Typography>
                   <Box className="verticalFit">
                     <RepositoryResourceBrowser repository={repository} checkedChanged={setCheckedChips} refresh={refresh} />

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -8,6 +8,8 @@ import Grid from "@material-ui/core/Grid";
 import AddIcon from "@material-ui/icons/Add";
 import Box from "@material-ui/core/Box";
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import Tooltip from '@material-ui/core/Tooltip';
 import CircularProgress from "@material-ui/core/CircularProgress";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -322,7 +324,10 @@ export const RepositoryPage = (props: any) => {
 
 
                     <Typography component="h2" variant="h2" className="primary-heading">
-                      Overview
+                      Overview <Tooltip title={`The repository overview page always shows the latest (current) version and contents of the repository. To see its previous version and contents, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
+                      <InfoOutlinedIcon fontSize="small"/>
+                    </Tooltip>
+
                     </Typography>
                   </Box>
                   <Box className={classes.repositoryInformation}>

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -48,7 +48,7 @@ import { CodeBranchIcon } from "../components/icons";
 
 const useStyles = makeStyles((theme) => ({
   infoIcon: {
-    fontSize: "0.9rem",
+    fontSize: "small",
     verticalAlign: "middle",
     color: paragraph,
   },

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -326,7 +326,7 @@ export const RepositoryPage = (props: any) => {
               <Grid item={true} xs={12} md={6} className="verticalFill">
                 <Box className="flex-grow-1 scrollbar" maxWidth="100%" position="relative">
                   <Box display="flex" alignItems="center" justifyContent="space-between">
-                    <Typography component="h2" variant="h2" className="primary-heading">
+                    <Typography component="h2" variant="h2" className="primary-heading" style={{ width: "100%" }}>
                       Overview <Tooltip title={`Repositories provide views of files in public resources that have been indexed in OSBv2 by users. Use the Repository Contents pane on the right to select files from this repository to add to your workspaces.`}>
                         <InfoOutlinedIcon className={classes.infoIcon}/>
                       </Tooltip>
@@ -417,7 +417,7 @@ export const RepositoryPage = (props: any) => {
               <Grid item={true} xs={12} md={6} className="verticalFill">
                 <Box className={`verticalFit ${classes.repositoryResourceBrowserBox}`}>
                   <Box display="flex" alignItems="center" justifyContent="space-between">
-                    <Typography component="h2" variant="h2">
+                    <Typography component="h2" variant="h2" style={{ width: "100%" }}>
                       Repository contents <Tooltip title={`The file list below shows the latest (current) version and contents of the repository. Select files and folders below to add to your workspaces. To see the previous version and contents of the repository, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
                         <InfoOutlinedIcon className={classes.infoIcon}/>
                       </Tooltip>

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -332,7 +332,7 @@ export const RepositoryPage = (props: any) => {
                     </Typography>
                     {
                       repository.user && (repository.user.firstName || repository.user.lastName) && <Typography component="p" variant="body2">
-                        By {`${repository.user.firstName} ${repository.user.lastName}`} {repository.timestampUpdated && `- last updated ${repository.timestampUpdated.toDateString()}`}
+                        Added by {`${repository.user.firstName} ${repository.user.lastName}`} {repository.timestampCreated && ` on ${repository.timestampCreated.toDateString()}`}
                       </Typography>
                     }
                     {

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -47,6 +47,11 @@ import { CodeBranchIcon } from "../components/icons";
 
 
 const useStyles = makeStyles((theme) => ({
+  infoIcon: {
+    fontSize: "0.9rem",
+    verticalAlign: "middle",
+    color: paragraph,
+  },
   linkButton: {
     position: 'absolute',
     right: 0,
@@ -325,7 +330,7 @@ export const RepositoryPage = (props: any) => {
 
                     <Typography component="h2" variant="h2" className="primary-heading">
                       Overview <Tooltip title={`Repositories provide views of files in public resources that have been indexed in OSBv2 by users. Use the Repository Contents pane on the right to select files from this repository to add to your workspaces.`}>
-                      <InfoOutlinedIcon fontSize="small"/>
+                        <InfoOutlinedIcon className={classes.infoIcon}/>
                     </Tooltip>
 
                     </Typography>
@@ -415,7 +420,7 @@ export const RepositoryPage = (props: any) => {
                 <Box className={`verticalFit ${classes.repositoryResourceBrowserBox}`}>
                   <Typography component="h2" variant="h2">
                     Repository contents <Tooltip title={`The file list below shows the latest (current) version and contents of the repository. Select files and folders below to add to your workspaces. To see the previous version and contents of the repository, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
-                      <InfoOutlinedIcon fontSize="small"/>
+                      <InfoOutlinedIcon className={classes.infoIcon}/>
                     </Tooltip>
                   </Typography>
                   <Box className="verticalFit">


### PR DESCRIPTION
This is what it looks like now:

![osbv2-repo-page-tooltip](https://user-images.githubusercontent.com/102575/151391112-37a1f133-f94b-4139-b59d-8ad8f9c9c6c4.png)

I also modified "Resources" to "Repository contents", because the list isn't showing what we mean by "resources" in OSBv2.

Things to check:

- text of the tooltip
- styling of the tooltip info icon