### PR TITLE
fix(workspace-page): use `div` for Typography

### DIFF
--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -243,7 +243,7 @@ export const WorkspacePage = (props: any) => {
                   <Divider />
                 </>}
 
-              <Typography component="p" variant="body1"><MarkdownViewer text={workspace.description} /></Typography>
+              <Typography component="div" variant="body1"><MarkdownViewer text={workspace.description} /></Typography>
             </Box>
 
           </Box>


### PR DESCRIPTION
If we use `p`, React gives us a DOM warning saying that the `div` (from the
MarkdownViewer component), cannot be a descendent of a `p` (from the
Typography component). So we use a `div` instead.

Fixes #365