### PR TITLE
Fix/issue373

### DIFF
--- a/applications/osb-portal/src/components/error-dialog/ErrorDialog.tsx
+++ b/applications/osb-portal/src/components/error-dialog/ErrorDialog.tsx
@@ -10,36 +10,32 @@ import * as Sentry from '@sentry/react';
 export const ErrorDialog = (props: any) => {
   const handleClose = () => {
     props.setError(null);
+    window.open("/", "_self");
   };
 
   const handleReport = () => {
     Sentry.captureException(new Error(props.error));
-    handleClose();
+    window.open("https://github.com/OpenSourceBrain/OSBv2/issues/new");
   };
 
-  if (props.error !== null){
-    const alerts = <Alert severity="error" key={1}><div className="errorAlertDiv" key={"div-1"} dangerouslySetInnerHTML={{ __html: props.error }} /></Alert>;
+  return (<Dialog
+    open={props.error !== null}
+    onClose={handleClose}
+    aria-labelledby="alert-dialog-title"
+    aria-describedby="alert-dialog-description"
+  >
+    <DialogTitle id="alert-dialog-title">{"Error"}</DialogTitle>
+    <DialogContent>
+      <Alert severity="error" key={1}><div className="errorAlertDiv" key={"div-1"} dangerouslySetInnerHTML={{ __html: props.error }} /></Alert>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={handleReport} color="primary" autoFocus={true}>
+        Report
+      </Button>
+      <Button onClick={handleClose} color="primary">
+        Close
+      </Button>
+    </DialogActions>
+  </Dialog>);
 
-    return (<Dialog
-      open={props.error !== null}
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-    >
-      <DialogTitle id="alert-dialog-title">{"Error"}</DialogTitle>
-      <DialogContent>
-        {alerts}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleReport} color="primary">
-          Report
-        </Button>
-        <Button onClick={handleClose} color="primary" autoFocus={true}>
-          Close
-        </Button>
-      </DialogActions>
-    </Dialog>);
-  }
-
-  return <div />;
 };

--- a/applications/osb-portal/src/components/index.ts
+++ b/applications/osb-portal/src/components/index.ts
@@ -120,7 +120,7 @@ export const MainMenu = connect(null, dispatchMainMenuProps)(mainMenu)
 const genericDispatch = (dispatch: Dispatch) => ({ dispatch: (action: AnyAction) => dispatch(action) });
 export const WorkspaceFrame = connect(mapSelectedWorkspaceStateToProps, genericDispatch)(workspaceFrame)
 export const WorkspaceOpenPage = connect(null, dispatchWorkspaceProps)(workspaceOpenPage);
-export const WorkspacePage = connect(mapUserStateToProps, dispatchWorkspaceProps)(workspacePage);
+export const WorkspacePage = connect(mapUserStateToProps, { ...dispatchWorkspaceProps, ...dispatchErrorProps })(workspacePage);
 export const RepositoryPage = connect(mapUserStateToProps)(repositoryPage)
 export const UserPage = connect(mapUserStateToProps)(userPage)
 export const RepositoriesPage = connect(mapUserAndTagsToProps, dispatchTagsProps)(repositoriesPage)

--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { useHistory, useParams } from "react-router-dom";
-import { MainMenu } from "../components/index";
+import { MainMenu, ErrorDialog } from "../components/index";
 import Box from "@material-ui/core/Box";
 import Chip from "@material-ui/core/Chip";
 import Typography from "@material-ui/core/Typography";
@@ -152,7 +152,12 @@ export const WorkspacePage = (props: any) => {
   React.useEffect(() => {
     WorkspaceService.getWorkspace(parseInt(workspaceId, 10)).then((ws) => {
       setWorkspace(ws);
-    });
+      props.setError(null);
+    },
+    (error) => {
+      const errorMessage = `Oops! This workspace could not be accessed. (Code: ${error.status})`;
+      props.setError(errorMessage);
+    })
   }, [refresh]);
 
   const handleCloseEditWorkspace = () => {

--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -154,9 +154,8 @@ export const WorkspacePage = (props: any) => {
       setWorkspace(ws);
       props.setError(null);
     },
-    (error) => {
-      const errorMessage = `Oops! This workspace could not be accessed. (Code: ${error.status})`;
-      props.setError(errorMessage);
+    () => {
+      props.setError("Oops! This workspace could not be accessed.");
     })
   }, [refresh]);
 


### PR DESCRIPTION
![Screenshot 2022-02-25 at 16-37-25 Open Source Brain](https://user-images.githubusercontent.com/102575/155752659-633e2ce1-7f77-4648-bb55-a570d1bf3369.png)


I had to make the `setError` dispatch available to the WorkspacePage here. Questions:

- does this need to be done for each page individually now?
- does this need to be done for all code snippets where a service method is called

or is there a general way of implementing this globally perhaps so that whenever a service method call fails, the error gets thrown with the appropriate error code?