### PR TITLE
debounce repository searches

### DIFF
--- a/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
@@ -164,6 +164,11 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
    * implement infinite scroll
    */
   const handleTagInput = (value?: any, tagpage?: number) => {
+      setTagSearchValue(value);
+      debouncedTagInputUpdate(value, tagpage);
+  }
+
+  const debouncedTagInputUpdate = React.useCallback(debounce((value?: any, tagpage?: number) => {
     let query: any;
     if ((value !== "") && (value !== undefined)){
       query = "tag__like=" + value;
@@ -172,7 +177,6 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
       const tags = tagsInformation.tags.map(tagObject => {
         return tagObject.tag;
       });
-      setTagSearchValue(value);
       setTagPage(tagsInformation.pagination.currentPage);
       setTotalTagPages(tagsInformation.pagination.numberOfPages);
       if (tagpage !== undefined) {
@@ -182,7 +186,7 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
         setSearchTagOptions(tags.sort((a: string, b: string) => a.localeCompare(b)));
       }
     });
-  }
+  }, 500), []);
 
   return (
     <>

--- a/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoriesPage/RepositoriesPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useHistory } from 'react-router-dom';
+import debounce from "lodash/debounce";
 
 import Box from "@material-ui/core/Box";
 
@@ -148,6 +149,10 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
     setSearchFilterValues({ ...searchFilterValues, types: repositoryTypes });
   }
 
+  const debouncedHandleSearchFilter = React.useCallback(debounce((newTextFilter: string) => {
+    setSearchFilterValues({ ...searchFilterValues, text: newTextFilter });
+  }, 500), []);
+
   /* This function handles changes to the input in the Autocomplete tag box.
    *
    * Initially, when the autocomplete box is populated, no text is provided to
@@ -267,7 +272,7 @@ export const RepositoriesPage = ({ user }: { user: UserInfo }) => {
               </FormControl>
             </Popover>
 
-            <RepositoriesSearch filterChanged={(newTextFilter) => setSearchFilterValues({ ...searchFilterValues, text: newTextFilter })} />
+            <RepositoriesSearch filterChanged={(newTextFilter) => debouncedHandleSearchFilter(newTextFilter)} />
             {user && (
               <>
                 <Divider orientation="vertical" flexItem={true} className={classes.divider} />


### PR DESCRIPTION
debounces both the tag and text fields of the repository search

requires #398 to be merged first I think, because that's where I've included `lodash` in the npm deps.