### PR TITLE
feat(workspace-page): set most recently used app as first option

### DIFF
--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -159,7 +159,7 @@ export const WorkspacePage = (props: any) => {
 
       // Populate ordered list from OSBApplications
       // set last used application as first entry if it is set
-      let apps = ws ? ws.lastOpen.type.application.name ? [PREFIX_TEXT + ws.lastOpen.type.application.name] : [] : null;
+      const apps = ws ? ws.lastOpen.type.application.name ? [PREFIX_TEXT + ws.lastOpen.type.application.name] : [] : null;
       for (const app of Object.keys(OSBApplications)) {
         if (!apps.includes(PREFIX_TEXT + OSBApplications[app].name)) {
             apps.push(PREFIX_TEXT + OSBApplications[app].name);


### PR DESCRIPTION
First, instead of hard-coding apps here, we use the OSBApplications
dictionary. This way, if a new app is used, only the OSBApplications
dictionary needs to be updated.

Next, using this dictionary, we construct the text to be shown in the
options, using the most recently used app as the first option if it
exists.

Finally, to open the app, because we know the option text format, we can
quickly check the string and open the necessary app.

Fixes #370