### PR TITLE
chore(main-menu): add link to chat channel over Matrix

### DIFF
--- a/applications/osb-portal/src/components/menu/MainMenu.tsx
+++ b/applications/osb-portal/src/components/menu/MainMenu.tsx
@@ -42,6 +42,7 @@ export const MainMenu = (props: any) => {
           className={classes.button + " " + classes.firstButton}
           items={[
             { label: "Documentation", callback: () => window.open("https://docs.opensourcebrain.org/OSBv2/Overview.html") },
+            { label: "Chat", callback: () => window.open("https://matrix.to/#/%23OpenSourceBrain_community:gitter.im?utm_source=gitter") },
             { label: "About", callback: handleDialogOpen },
           ]}
         />


### PR DESCRIPTION
Why not use a Gitter link?

Gitter was taken over by Element, who are developing Matrix, and all
Gitter channels are now available of Matrix. Gitter stays for the time
being, but it is expected that Matrix will be the new platform.

See: https://matrix.org/blog/2020/12/07/gitter-now-speaks-matrix#whats-next

---------

Doesn't need to be merged yet, but will be good to have up before the CNS launch so people can contact us synchronously when required.