### PR TITLE
fix(workspace-editor): ensure dialog is rendered fresh each time

### DIFF
--- a/applications/osb-portal/src/components/workspace/WorkspaceActionsMenu.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceActionsMenu.tsx
@@ -160,11 +160,13 @@ export default (props: WorkspaceActionsMenuProps) => {
 
         </NestedMenuItem>
       </Menu>
-        <WorkspaceEditor
-          open={editWorkspaceOpen}
-          title={"Edit workspace: " + props.workspace.name}
-          closeHandler={handleCloseEditWorkspace}
-          workspace={props.workspace} onLoadWorkspace={handleCloseEditWorkspace} />
+      {editWorkspaceOpen &&
+      <WorkspaceEditor
+        open={editWorkspaceOpen}
+        title={"Edit workspace: " + props.workspace.name}
+        closeHandler={handleCloseEditWorkspace}
+        workspace={props.workspace} onLoadWorkspace={handleCloseEditWorkspace} />
+      }
       <OSBLoader active={cloneInProgress} fullscreen={true} handleClose={handleCloseMenu} messages={["Cloning workspace. Please wait."]} />
       <Snackbar classes={{  root: classes.snackbar }} open={cloneComplete} onClose={() => setCloneComplete(false)} message="Workspace cloned" anchorOrigin={{"vertical": "bottom", "horizontal": "left"}}
         autoHideDuration={5000}

--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -268,7 +268,7 @@ export const WorkspacePage = (props: any) => {
           </Box>
         </Box>
 
-        {canEdit && <WorkspaceEditor
+        {canEdit && editWorkspaceOpen && <WorkspaceEditor
           open={editWorkspaceOpen}
           title={"Edit workspace: " + workspace.name}
           closeHandler={handleCloseEditWorkspace}


### PR DESCRIPTION
This also ensures that other side-effects like the loader still being
visible after the dialog has closed to not happen.

Fixes #429