### PR TITLE
Add figshare support

### DIFF
--- a/applications/osb-portal/src/components/repository/EditRepoDialog.tsx
+++ b/applications/osb-portal/src/components/repository/EditRepoDialog.tsx
@@ -381,7 +381,7 @@ export const EditRepoDialog = ({
             >
               <MenuItem value={RepositoryContentType.Experimental}>
                 <Checkbox color="primary" checked={formValues.contentTypesList.includes(RepositoryContentType.Experimental)} />
-                <ListItemText primary="NWB Experimental Data" />
+                <ListItemText primary="Experimental Data" />
               </MenuItem>
               <MenuItem value={RepositoryContentType.Modeling}>
                 <Checkbox color="primary" checked={formValues.contentTypesList.includes(RepositoryContentType.Modeling)} />

--- a/applications/osb-portal/src/components/repository/EditRepoDialog.tsx
+++ b/applications/osb-portal/src/components/repository/EditRepoDialog.tsx
@@ -315,9 +315,7 @@ export const EditRepoDialog = ({
                 onChange={(e) => handleInput(e, "repositoryType")}
                 IconComponent={KeyboardArrowDownIcon}
               >
-                {Object.values(RepositoryType)
-                  .filter((t) => t === RepositoryType.Github || t === RepositoryType.Dandi) // TODO remove when all repo types are available
-                  .map((repositoryType) => (
+                {Object.values(RepositoryType).map((repositoryType) => (
                     <MenuItem key={repositoryType} value={repositoryType}>
                       {repositoryType}
                     </MenuItem>
@@ -350,7 +348,7 @@ export const EditRepoDialog = ({
         </Box>
         {contexts && <Box className="form-group">
 
-          <Typography component="label">Default Branch</Typography>
+          <Typography component="label">Default Branch/Version</Typography>
           <FormControl variant="outlined" fullWidth={true} error={Boolean(error.defaultContext)}>
             <Select
               value={formValues.defaultContext}

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -306,6 +306,9 @@ export const RepositoryPage = (props: any) => {
       // For dandi, the URL is: repo/version
       case "dandi":
         return repository.uri + "/" + repository.defaultContext;
+      // For figshare, there does not seem to be a version specific URL
+      case "figshare":
+        return repository.uri
       default:
         return "#"
     }

--- a/applications/workspaces/server/workspaces/service/osbrepository/adapters/figshareadapter.py
+++ b/applications/workspaces/server/workspaces/service/osbrepository/adapters/figshareadapter.py
@@ -1,34 +1,133 @@
-from cloudharness import log as logger
+import re
+import sys
+import requests
+import concurrent.futures
 
-from workspaces.models import FigshareRepositoryResource, RepositoryResource, RepositoryResourceNode
+from cloudharness import log as logger
+from workspaces.models import FigshareRepositoryResource, RepositoryResourceNode
 
 from .utils import add_to_tree
 
 
+class FigShareException(Exception):
+    pass
+
+
 class FigShareAdapter:
-    def __init__(self, osbrepository):
+    """
+    Adapter for FigShare
+
+    https://docs.figshare.com/
+    """
+
+    def __init__(self, osbrepository, uri=None):
         self.osbrepository = osbrepository
+        self.uri = uri if uri else osbrepository.uri
+        # even for different figshare "instances", the IDs remain the same, and
+        # there's only one API end point
+        self.api_url = "https://api.figshare.com/v2/"
+
+        # hard coded list of valid figshare URls
+        figshare_urls = [
+            "figshare.com",  # default
+            "rdr.ucl.ac.uk"  # UCL
+        ]
+
+        # create composite for re
+        url_str = "https://("
+        for v in figshare_urls:
+            url_str += (v + "|")
+        url_str += ")"
+
+        try:
+            self.article_id = re.search(
+                f"{url_str}/.*/(.*?)$",
+                self.uri.strip("/")).group(2)
+
+        except AttributeError:
+            raise FigShareException(f"{uri} is not a valid Figshare URL")
+
+    def get_json(self, uri):
+        logger.debug(f"Getting: {uri}")
+        try:
+            r = requests.get(
+                uri,
+            )
+            if r.status_code == 200:
+                return r.json()
+            else:
+                raise FigShareException(
+                    f"Unexpected requests status code: {r.status_code}")
+        except Exception as e:
+            raise FigShareException("Unexpected error:", sys.exc_info()[0])
 
     def get_contexts(self):
-        return list([])
+        result = self.get_json(
+            f"{self.api_url}/articles/{self.article_id}/versions")
+        # returned as integers, so cast to string before returning
+        return [str(v["version"]) for v in result]
 
     def get_resources(self, context):
-        contents = {"tree": []}
+        # can also be fetched from the full article end point, but this is more
+        # direct
+        contents = self.get_json(
+            f"{self.api_url}/articles/{self.article_id}/files")
 
-        tree = RepositoryResourceNode(RepositoryResource(name="/"), children=[])
-        for git_obj in contents["tree"]:
-            add_to_tree(tree, git_obj["path"].split("/"), osbrepository_id=self.osbrepository.id)
+        tree = RepositoryResourceNode(
+            resource=FigshareRepositoryResource(
+                name="/",
+                path="/",
+                osbrepository_id=self.osbrepository.id,
+            ),
+            children=[],
+        )
+
+        for afile in contents:
+            add_to_tree(
+                tree=tree,
+                tree_path=[afile["name"]],
+                path=afile["download_url"],
+                size=afile["size"],
+                osbrepository_id=self.osbrepository.id,
+            )
 
         return tree
 
-    def get_latest_hash(self, download_url):
-        return 123
+    def _get_figshare_info(self, context):
+        result = self.get_json(
+            f"{self.api_url}/articles/{self.article_id}/versions/{context}")
+        return result
 
     def get_description(self, context):
-        return "Description"
+        try:
+            result = self._get_figshare_info(context)
+            return result["description"]
+        except Exception as e:
+            logger.debug("unable to get the description from Figshare, %", str(e))
+            return ""
 
-    def create_copy_task(self, name, folder, path):
+    def get_tags(self, context):
+        try:
+            result = self._get_figshare_info(context)
+            return result["tags"]
+        except Exception as e:
+            logger.debug("unable to get the tags from Figshare, %", str(e))
+            return []
+
+    def create_copy_task(self, workspace_id, name, path):
+        # download the resource
+        import workspaces.service.workflow as workflow
         name = name if name != "/" else self.osbrepository.name
-        folder = self.osbrepository.name + path.replace(self.download_base_url + "branches", "")
-        folder = folder[: folder.rfind("/")]
-        # do something...
+        # no file tree in FigShare
+        folder = self.osbrepository.name
+        # username / password are optional and future usage,
+        # e.g. for accessing non public repos
+        return workflow.create_copy_task(
+            image_name="workspaces-figshare-copy",
+            workspace_id=workspace_id,
+            name=name,
+            folder=folder,
+            path=path,
+            username="",
+            password="",
+        )


### PR DESCRIPTION
adds figshare support for figshare and the ucl instance

- the only thing I haven't been able to test properly is if the resource is being downloaded correctly---still seeing the spinner here in the resource pane (but that was supposed to be fixed in #368?)


creation of the repo, and creation of workspaces from the repo seems to be fine.

Note that this touches a few lines of the editrepo dialog component, so may conflict with #434 

Fixes #390 