### PR TITLE
feat(figshare): add figshare-copy

### DIFF
--- a/applications/workspaces/server/workspaces/service/osbrepository/adapters/figshareadapter.py
+++ b/applications/workspaces/server/workspaces/service/osbrepository/adapters/figshareadapter.py
@@ -120,10 +120,16 @@ class FigShareAdapter:
         name = name if name != "/" else self.osbrepository.name
         # no file tree in FigShare
         folder = self.osbrepository.name
+
+        # download everything: the handler will fetch the complete file list
+        # and download them all
+        if not path or path == "/":
+            path = self.article_id
+
         # username / password are optional and future usage,
         # e.g. for accessing non public repos
         return workflow.create_copy_task(
-            image_name="workflows-extract-download",
+            image_name="workspaces-figshare-copy",
             workspace_id=workspace_id,
             name=name,
             folder=folder,

--- a/applications/workspaces/tasks/figshare-copy/Dockerfile
+++ b/applications/workspaces/tasks/figshare-copy/Dockerfile
@@ -1,0 +1,15 @@
+ARG CLOUDHARNESS_BASE
+FROM $CLOUDHARNESS_BASE
+
+# much faster than curl/wget
+# https://pkgs.alpinelinux.org/packages?name=aria2&branch=edge
+RUN apk add aria2 curl
+
+
+ADD . /
+
+ENV shared_directory /
+ENV workspace_id 1
+
+RUN chmod +x ./run.sh
+CMD ./run.sh

--- a/applications/workspaces/tasks/figshare-copy/run.sh
+++ b/applications/workspaces/tasks/figshare-copy/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# remove the pvc from the path (if it has one)
+# and append the folder
+export download_path=`echo $shared_directory | cut -d ":" -f 2`/"${folder}"
+
+mkdir -p "${download_path}"
+cd "${download_path}"
+
+# if a file url is passed
+if echo "${url}" | grep -E "https://" 2>&1 > /dev/null
+then
+    echo Figshare copy "${url}" to "${download_path}"
+    echo "${url}" > filelist
+else
+    # if the article id is passed, download all files
+    echo Figshare copy all files of article "${url}" to "${download_path}"
+    curl -X GET "https://api.figshare.com/v2/articles/${url}/files" | tr "}" "\n" | grep -Eo "https://ndownloader.figshare.com/files/[[:digit:]]+" > filelist
+fi
+
+# multiple downloads concurrently, with multiple connections to the server
+# overwrite files if they are downloaded again
+aria2c --retry-wait=2 --max-tries=5 --input-file=filelist --max-concurrent-downloads=5 --max-connection-per-server=5 --allow-overwrite "true" --auto-file-renaming "false"
+
+# delete the file list
+rm filelist -f
+
+# fix permissions
+chown -R 1000:1000 "${download_path}"


### PR DESCRIPTION
Adds a new figshare copy task that users `aria2c` to download files from
figshare.

This handles both cases:

- where files are selected for addition
- where no files are selected and so all of them are to be added

Fixes #449