### PR TITLE
Feat/link tooltips to docs

### DIFF
--- a/applications/osb-portal/src/components/workspace/drawer/WorkspaceInteractions.tsx
+++ b/applications/osb-portal/src/components/workspace/drawer/WorkspaceInteractions.tsx
@@ -18,6 +18,7 @@ import ExpansionPanelSummary from "@material-ui/core/AccordionSummary";
 import ExpansionPanelDetails from "@material-ui/core/AccordionDetails";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import Tooltip from '@material-ui/core/Tooltip';
+import Link from "@material-ui/core/Link";
 import Chip from '@material-ui/core/Chip';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem'
@@ -205,7 +206,8 @@ export default (props: WorkspaceProps | any) => {
             <Typography
               variant="h4"
               className={classes.flexCenter}>
-              {workspace.name}<Tooltip style={{ marginLeft: '0.3em' }} title="Resources are special files that can be opened with applications supported by Open Source Brain. To see all your files, and upload non-resource files, please open the workspace in the JupyterLab application.">
+              {workspace.name}<Tooltip interactive={true} style={{ marginLeft: '0.3em' }} title={
+                <>Resources are special files that can be opened with applications supported by Open Source Brain. To see all your files, and upload non-resource files, please open the workspace in the JupyterLab application. <Link href="https://docs.opensourcebrain.org/OSBv2/Workspaces.html" target="_blank">Learn more...</Link></>}>
                 <InfoOutlinedIcon fontSize="small"/>
               </Tooltip>
               {!canEdit && <Tooltip style={{ marginLeft: '0.3em' }} title="You do not have permissions to modify this workspace."><ReadOnlyIcon fontSize="small" /></Tooltip>}

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -350,7 +350,8 @@ export const RepositoryPage = (props: any) => {
                 <Box className="flex-grow-1 scrollbar" maxWidth="100%" position="relative">
                   <Box display="flex" alignItems="center" justifyContent="space-between">
                     <Typography component="h2" variant="h2" className="primary-heading" style={{ width: "100%" }}>
-                      Overview <Tooltip title={`Repositories provide views of files in public resources that have been indexed in OSBv2 by users. Use the Repository Contents pane on the right to select files from this repository to add to your workspaces.`}>
+                      Overview <Tooltip interactive={true} title={
+                        <>Repositories provide views of files in public resources that have been indexed in OSBv2 by users. Use the Repository Contents pane on the right to select files from this repository to add to your workspaces. <Link href="https://docs.opensourcebrain.org/OSBv2/Repositories.html" target="_blank">Learn more...</Link></>}>
                         <InfoOutlinedIcon className={classes.infoIcon}/>
                       </Tooltip>
 
@@ -442,7 +443,9 @@ export const RepositoryPage = (props: any) => {
                 <Box className={`verticalFit ${classes.repositoryResourceBrowserBox}`}>
                   <Box display="flex" alignItems="center" justifyContent="space-between">
                     <Typography component="h2" variant="h2" style={{ width: "100%" }}>
-                      Repository contents <Tooltip title={`The file list below shows the latest (current) version and contents of the repository. Select files and folders below to add to your workspaces. To see the previous version and contents of the repository, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`}>
+                      Repository contents <Tooltip interactive={true} title={
+                        <>{`The file list below shows the latest (current) version and contents of the repository. Select files and folders below to add to your workspaces. To see the previous version and contents of the repository, please view the repository on ${Resources[repository.repositoryType] || repository.repositoryType}.`} <Link href="https://docs.opensourcebrain.org/OSBv2/Repositories.html" target="_blank">Learn more...</Link>
+                        </>}>
                         <InfoOutlinedIcon className={classes.infoIcon}/>
                       </Tooltip>
                     </Typography>


### PR DESCRIPTION
Minor cosmetic tweak: adds "learn more" links to the docs in a few tool tips on the workspaces page and the repositories page

![Screenshot from 2022-05-25 15-33-58](https://user-images.githubusercontent.com/102575/170287772-c8ff459e-5650-4bea-8123-595f2e159406.png)
