### PR TITLE
feat(user-editor): disable username field (fixes #464)

### DIFF
--- a/applications/osb-portal/src/components/user/UserEditor.tsx
+++ b/applications/osb-portal/src/components/user/UserEditor.tsx
@@ -196,7 +196,7 @@ export default (props: UserEditProps) => {
                 </Box>
                 <Box mb={1} mt={1}>
                     <Typography component="label" variant="h6">Username</Typography>
-                    <TextField error={props.error.username} helperText={props.error.username} className={classes.textFieldWithIcon} fullWidth={true} onChange={setProfileUserName} variant="outlined" defaultValue={props.profileForm.username} InputProps={{
+                    <TextField disabled={true} error={props.error.username} helperText={props.error.username} className={classes.textFieldWithIcon} fullWidth={true} onChange={setProfileUserName} variant="outlined" defaultValue={props.profileForm.username} InputProps={{
                         startAdornment: (
                             <Box className={classes.inputIconBox}>
                                 <AlternateEmail fontSize="small" />


### PR DESCRIPTION
This causes the colour of the border to change to a lighter grey, though. Haven't been able to figure out how to prevent that change yet.

looking into why the e-mail field isn't populated now.

Fixes #464 