### PR TITLE
fix: correct check for null object (fixes #499)

### DIFF
--- a/applications/workspaces/server/workspaces/service/model_service.py
+++ b/applications/workspaces/server/workspaces/service/model_service.py
@@ -38,7 +38,7 @@ from workspaces.utils import dao_entity2dict
 def rm_null_values(dikt):
     tmp = {}
     for k, v in dikt.items():  # remove null fields from dict
-        if v:
+        if v is not None:
             tmp.update({k: v})
     return tmp
 


### PR DESCRIPTION
```
if v:
```

will return `false` if `v` is set to `false`. This means if a boolean
attribute is set to `false`, it is always removed from the set of
attributes being updated---thus never being updated in a `put` request.