### PR TITLE
feat(workspaces): keep resource drawer closed by default for jupyter

### DIFF
--- a/applications/osb-portal/src/components/workspace/drawer/WorkspaceDrawer.tsx
+++ b/applications/osb-portal/src/components/workspace/drawer/WorkspaceDrawer.tsx
@@ -97,8 +97,9 @@ export const WorkspaceDrawer: React.FunctionComponent<WorkspaceDrawerProps> = ({
   }
   const classes = useStyles();
 
-  const [open, setOpen] = React.useState(true);
   const { app } = useParams<{ app: string }>();
+  // Keep drawer closed for jupyter by default
+  const [open, setOpen] = React.useState(app === "jupyter" ? false : true);
 
   const [currentResource, setCurrentResource] = React.useState<WorkspaceResource>(!app ? workspace.lastOpen : null);
 


### PR DESCRIPTION
Otherwise users see two "lists" of files here. For jupyter, we want them
to see the jupyter file browser.

fixes #508