### PR TITLE
feat(backoffice): use datagrid for responsive table

### DIFF
--- a/applications/backoffice/src/pages/HomePage.tsx
+++ b/applications/backoffice/src/pages/HomePage.tsx
@@ -107,7 +107,7 @@ export default (props: any) => {
 
   const dataColumns: GridColDef[] = [
     {
-      field: 'id', headerName: 'ID', renderCell: (param) => {return <><Link href={`${getHostname("")}${osbProfile}${param.value}`} target="_blank"> OSB </Link>&nbsp;|&nbsp;<Link href={`${getHostname("accounts")}${keycloakProfile}${param.value}`} target="_blank"> KeyCloak </Link></>},
+      field: 'id', headerName: 'Profile', renderCell: (param) => {return <><Link href={`${getHostname("")}${osbProfile}${param.value}`} target="_blank"> OSB </Link>&nbsp;|&nbsp;<Link href={`${getHostname("accounts")}${keycloakProfile}${param.value}`} target="_blank"> KeyCloak </Link></>},
       minWidth: 50, flex: 2,
     },
     {

--- a/applications/backoffice/src/pages/HomePage.tsx
+++ b/applications/backoffice/src/pages/HomePage.tsx
@@ -4,12 +4,6 @@ import Cookies from 'js-cookie'
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
 import Typography from '@mui/material/Typography';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import Link from '@mui/material/Link';
 import { DataGrid, GridColDef, GridValueGetterParams  } from '@mui/x-data-grid';
@@ -146,10 +140,6 @@ export default (props: any) => {
       minWidth: 50, flex: 1,
     }
   ]
-
-  const table =
-      <>
-      </>
 
   return <>
     { (error !== null) ? <>"An error occured: " { error }</> : (users === null || workspaces === null || repositories === null) ? <CircularProgress /> :

--- a/applications/backoffice/src/pages/HomePage.tsx
+++ b/applications/backoffice/src/pages/HomePage.tsx
@@ -113,7 +113,6 @@ export default (props: any) => {
       gridData.push(arow);
     })
 
-    console.log(`${JSON.stringify(gridData)}`)
     return gridData;
   }
 

--- a/applications/backoffice/src/pages/HomePage.tsx
+++ b/applications/backoffice/src/pages/HomePage.tsx
@@ -6,7 +6,7 @@ import Box from "@mui/material/Box";
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import Link from '@mui/material/Link';
-import { DataGrid, GridColDef, GridValueGetterParams  } from '@mui/x-data-grid';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import CircularProgress from '@mui/material/CircularProgress';
 
 import makeStyles from '@mui/styles/makeStyles';

--- a/applications/backoffice/src/pages/HomePage.tsx
+++ b/applications/backoffice/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import Link from '@mui/material/Link';
 import { DataGrid, GridColDef, GridValueGetterParams  } from '@mui/x-data-grid';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import makeStyles from '@mui/styles/makeStyles';
 
@@ -37,6 +38,7 @@ export default (props: any) => {
   const [ users, setUsers ] = React.useState<any[]>(null);
   const [ workspaces, setWorkspaces ] = React.useState<any>(null);
   const [ repositories, setRepositories ] = React.useState<any>(null);
+  const [ error, setError ] = React.useState<any>(null);
 
   const fetchInfo = () => {
     // Initialise APIs with token
@@ -47,17 +49,20 @@ export default (props: any) => {
       /* Does not require logging in */
       getUsers().then((userlist) => {
         setUsers(userlist);
-      });
+        setError(null);
+      }, (e) => setError(e));
 
       /* Requires user to be logged in, and to be admin to see all workspaces */
       WorkspaceService.fetchWorkspaces(null, null, 1, BIG_NUMBER_OF_ITEMS).then((workspaceList) => {
         setWorkspaces(workspaceList.items);
-      })
+        setError(null);
+      }, (e) => setError(e))
 
       /* Does not require logging in */
       RepositoryService.getRepositories(1, BIG_NUMBER_OF_ITEMS, null).then((repositoryList) => {
         setRepositories(repositoryList);
-      })
+        setError(null);
+      }, (e) => setError(e))
     }
   };
 
@@ -76,12 +81,6 @@ export default (props: any) => {
   React.useEffect(() => {
     fetchInfo();
   }, [ ]);
-
-  if (users === null){
-    return <>
-      Error: Could not fetch information. Please login and retry.
-    </>
-  }
 
   // Get hostname without sub-domain
   const getHostname = (subdomain: string) => {
@@ -151,22 +150,21 @@ export default (props: any) => {
 
   const table =
       <>
-        Summary: { `${users.length} users` } { workspaces !== null ? ` ${workspaces.length} workspaces,` : "? workspaces," } { repositories !== null ? ` and ${repositories.length} repositories.` : "? repositories." }
-        {workspaces !== null && repositories !== null &&
-          <div style={{ height: 400, width: '100%' }}>
-            <DataGrid
-              rows={getDataGridData()}
-              columns={dataColumns}
-              pageSize={20}
-              rowsPerPageOptions={[20, 50, 100]}
-            />
-          </div>
-        }
       </>
 
   return <>
-    <Box p={1}>
-      {table}
-    </Box>
+    { (error !== null) ? <>"An error occured: " { error }</> : (users === null || workspaces === null || repositories === null) ? <CircularProgress /> :
+      <Box p={1}>
+        Summary: { `${users.length} users` } { workspaces !== null ? ` ${workspaces.length} workspaces,` : "? workspaces," } { repositories !== null ? ` and ${repositories.length} repositories.` : "? repositories." }
+        <div style={{ height: 400, width: '100%' }}>
+          <DataGrid
+            rows={getDataGridData()}
+            columns={dataColumns}
+            pageSize={20}
+            rowsPerPageOptions={[20, 50, 100]}
+          />
+        </div>
+      </Box>
+    }
   </>
 };

--- a/applications/backoffice/src/pages/HomePage.tsx
+++ b/applications/backoffice/src/pages/HomePage.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import Cookies from 'js-cookie'
 
-import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
-import Typography from '@mui/material/Typography';
-import Paper from '@mui/material/Paper';
 import Link from '@mui/material/Link';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -15,8 +12,6 @@ import { initApis, getUsers } from  "../service/UserService";
 import { UserInfo } from '../types/user';
 import WorkspaceService from "../service/WorkspaceService"
 import RepositoryService from "../service/RepositoryService";
-
-import SearchFilter from '../types/searchFilter';
 
 const BIG_NUMBER_OF_ITEMS = 5000;
 


### PR DESCRIPTION
Looks like this now, and all columns can be sorted etc.

![Screenshot 2022-06-01 at 16-48-04 Open Source Brain](https://user-images.githubusercontent.com/102575/171446144-436067a2-cc4f-44e0-b0cc-0380d42f3813.png)
