### PR TITLE
open workspace button logic modified

### DIFF
--- a/applications/osb-portal/src/components/workspace/WorkspaceActionsMenu.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceActionsMenu.tsx
@@ -27,6 +27,7 @@ interface WorkspaceActionsMenuProps {
   deleteWorkspace?: (wsId: number) => void;
   refreshWorkspaces: () => void;
   user?: UserInfo;
+  isWorkspaceOpen:boolean
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -135,7 +136,7 @@ export default (props: WorkspaceActionsMenuProps) => {
         {canEdit && props.workspace.publicable && <MenuItem onClick={handlePrivateWorkspace}>Make private</MenuItem>}
         {props.user && props.user.isAdmin && props.workspace.publicable && !props.workspace.featured && <MenuItem onClick={handleFeaturedWorkspace}>Add to featured</MenuItem>}
         {props.user && props.user.isAdmin && props.workspace.featured && <MenuItem onClick={handleFeaturedWorkspace}>Remove from featured</MenuItem>}
-        <MenuItem onClick={handleOpenWorkspace}>Open workspace</MenuItem>
+        {!props.isWorkspaceOpen && <MenuItem onClick={handleOpenWorkspace}>Open workspace</MenuItem>}
         {props.user && <MenuItem onClick={handleCloneWorkspace}>Clone workspace</MenuItem>}
         <NestedMenuItem
           label="Open with..."

--- a/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceCard.tsx
@@ -122,7 +122,7 @@ export const WorkspaceCard = (props: Props) => {
         {!props.hideMenu &&
           <CardActions className={classes.actions}>
             <WorkspaceActionsMenu user={props.user} workspace={workspace}
-              updateWorkspace={props.updateWorkspace} deleteWorkspace={props.deleteWorkspace} refreshWorkspaces={props.refreshWorkspaces} />
+              updateWorkspace={props.updateWorkspace} deleteWorkspace={props.deleteWorkspace} refreshWorkspaces={props.refreshWorkspaces} isWorkspaceOpen={false} />
           </CardActions>
         }
 

--- a/applications/osb-portal/src/components/workspace/drawer/WorkspaceInteractions.tsx
+++ b/applications/osb-portal/src/components/workspace/drawer/WorkspaceInteractions.tsx
@@ -214,7 +214,7 @@ export default (props: WorkspaceProps | any) => {
             </Typography>
 
             <Box p={2}>
-              <WorkspaceActionsMenu workspace={workspace} user={props.user} updateWorkspace={props.updateWorkspace} deleteWorkspace={deleteWorkspace} refreshWorkspaces={handleWorkspaceRefresh} />
+              <WorkspaceActionsMenu workspace={workspace} user={props.user} updateWorkspace={props.updateWorkspace} deleteWorkspace={deleteWorkspace} refreshWorkspaces={handleWorkspaceRefresh} isWorkspaceOpen={true}/>
             </Box>
             <Menu
               id="simple-menu"
@@ -270,7 +270,7 @@ export default (props: WorkspaceProps | any) => {
           {props.workspace.name}
 
           <IconButton>
-            <WorkspaceActionsMenu workspace={workspace} user={props.user} updateWorkspace={props.updateWorkspace} deleteWorkspace={props.deleteWorkspace} refreshWorkspaces={handleWorkspaceRefresh} />
+            <WorkspaceActionsMenu workspace={workspace} user={props.user} updateWorkspace={props.updateWorkspace} deleteWorkspace={props.deleteWorkspace} refreshWorkspaces={handleWorkspaceRefresh} isWorkspaceOpen={true} />
           </IconButton>
         </div>
       </>


### PR DESCRIPTION
Problem: there should be no "open workspace" button on an already opened workspace

<img width="667" alt="osbv2" src="https://user-images.githubusercontent.com/67194168/184180909-5505135c-3d11-4f94-98c6-a0192d04f7a5.png">

Solution: I passed the isWorkspaceOpen prop to identify on which page is this button, so if it is on already open page this button will not appear
