### PR TITLE
#430 add check isAdmin to prevent opening repository menu for users

### DIFF
--- a/applications/osb-portal/package-lock.json
+++ b/applications/osb-portal/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/applications/osb-portal/src/components/repository/RepositoryActionsMenu.tsx
+++ b/applications/osb-portal/src/components/repository/RepositoryActionsMenu.tsx
@@ -20,6 +20,7 @@ export default (props: RepositoryActionsMenuProps) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [repositoryEditorOpen, setRepositoryEditorOpen] = React.useState(false);
   const canEdit = canEditRepository(props.user, props.repository);
+  const { user } = props;
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -44,20 +45,23 @@ export default (props: RepositoryActionsMenuProps) => {
 
   return (
     <>
-      <IconButton size="small" onClick={handleClick}>
-        <Icons.Dots style={{ fontSize: "1rem", transform: 'rotate(90deg)' }} />
-      </IconButton>
-      <Menu
-        id="simple-menu"
-        anchorEl={anchorEl}
-        keepMounted={true}
-        open={Boolean(anchorEl)}
-        onClose={handleCloseMenu}
-      >
-        {canEdit && <MenuItem onClick={handleEditRepository}>Edit</MenuItem>}
-      </Menu>
-      {repositoryEditorOpen && <EditRepoDialog user={props.user} title="Edit repository" dialogOpen={repositoryEditorOpen} setDialogOpen={setDialogOpen}
-        onSubmit={handleOnSubmit} repository={props.repository} />}
+      {
+        user.isAdmin && <><IconButton size="small" onClick={handleClick}>
+          <Icons.Dots style={{ fontSize: "1rem", transform: 'rotate(90deg)' }} />
+        </IconButton>
+          <Menu
+            id="simple-menu"
+            anchorEl={anchorEl}
+            keepMounted={true}
+            open={Boolean(anchorEl)}
+            onClose={handleCloseMenu}
+          >
+            {canEdit && <MenuItem onClick={handleEditRepository}>Edit</MenuItem>}
+          </Menu>
+          {repositoryEditorOpen && <EditRepoDialog user={props.user} title="Edit repository" dialogOpen={repositoryEditorOpen} setDialogOpen={setDialogOpen}
+            onSubmit={handleOnSubmit} repository={props.repository} />}
+        </>
+      }
     </>
   )
 }

--- a/applications/osb-portal/src/components/repository/RepositoryActionsMenu.tsx
+++ b/applications/osb-portal/src/components/repository/RepositoryActionsMenu.tsx
@@ -19,8 +19,8 @@ interface RepositoryActionsMenuProps {
 export default (props: RepositoryActionsMenuProps) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [repositoryEditorOpen, setRepositoryEditorOpen] = React.useState(false);
+  
   const canEdit = canEditRepository(props.user, props.repository);
-  const { user } = props;
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -43,10 +43,12 @@ export default (props: RepositoryActionsMenuProps) => {
     props.onAction(r);
   }
 
+  const isRenderable = canEdit || false; // for future updates 
+
   return (
     <>
       {
-        user.isAdmin && <><IconButton size="small" onClick={handleClick}>
+        isRenderable && <><IconButton size="small" onClick={handleClick}>
           <Icons.Dots style={{ fontSize: "1rem", transform: 'rotate(90deg)' }} />
         </IconButton>
           <Menu


### PR DESCRIPTION
Problem: Not admin users could access to menu on repository page which only admins should have access to 
<img width="1431" alt="imgOSBv2-430" src="https://user-images.githubusercontent.com/67194168/184316023-d3b65766-c23c-4574-aa20-95c6929f2357.png">
Solution: Added check 
