### PR TITLE
Updated the Dockerfile and removed errors .

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 

--- a/applications/nwb-explorer/Dockerfile
+++ b/applications/nwb-explorer/Dockerfile
@@ -33,21 +33,16 @@ USER root
 
 WORKDIR $FOLDER
 
-
-
 RUN rm -rf /var/lib/apt/lists
-
 RUN apt-get update -qq && \
     apt-get install -y python3-tk vim nano unzip git g++ libjpeg-dev zlib1g-dev -qq 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
 RUN pip install --no-cache-dir cython
 
 RUN groupadd -g $NB_GID jovyan && \
     usermod -g $NB_GID $NB_UID && \
     chown -R $NB_UID:$NB_GID /home/$NB_UID && \
-    chown -R $NB_UID:$NB_GID /opt/conda && \
     chown -R $NB_UID:$NB_GID /opt
 
 USER $NB_UID
@@ -57,8 +52,7 @@ RUN pip install -r requirements.txt --no-cache-dir
 COPY --from=clone $FOLDER .
 
 
-RUN mkdir -p /opt/workspace && \
-    chown -R $NB_UID:$NB_GID /opt/workspace
+RUN mkdir -p /opt/workspace
 RUN ln -s /opt/workspace workspace
 RUN mkdir -p /opt/home
 RUN python utilities/install.py --npm-skip --no-test

--- a/applications/nwb-explorer/Dockerfile
+++ b/applications/nwb-explorer/Dockerfile
@@ -40,7 +40,21 @@ RUN pip install cython --no-cache-dir
 RUN chown $NB_UID /opt
 RUN chown $NB_UID .
 
+--------
 
+RUN rm -rf /var/lib/apt/lists
+
+RUN apt-get update -qq && \
+    apt-get install -y python3-tk vim nano unzip git g++ libjpeg-dev zlib1g-dev -qq 
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir cython
+
+RUN groupadd -g $NB_GID jovyan && \
+    usermod -g $NB_GID $NB_UID && \
+    chown -R $NB_UID:$NB_GID /home/$NB_UID && \
+    chown -R $NB_UID:$NB_GID /opt/conda
 
 USER $NB_UID
 

--- a/applications/nwb-explorer/Dockerfile
+++ b/applications/nwb-explorer/Dockerfile
@@ -25,6 +25,7 @@ RUN npm run build
 ###
 FROM jupyter/base-notebook:hub-1.4.2
 ENV NB_UID=jovyan
+ENV NB_GID=1001
 ENV FOLDER=nwb-explorer
 USER root
 

--- a/applications/nwb-explorer/Dockerfile
+++ b/applications/nwb-explorer/Dockerfile
@@ -47,7 +47,8 @@ RUN pip install --no-cache-dir cython
 RUN groupadd -g $NB_GID jovyan && \
     usermod -g $NB_GID $NB_UID && \
     chown -R $NB_UID:$NB_GID /home/$NB_UID && \
-    chown -R $NB_UID:$NB_GID /opt/conda
+    chown -R $NB_UID:$NB_GID /opt/conda && \
+    chown -R $NB_UID:$NB_GID /opt
 
 USER $NB_UID
 

--- a/applications/nwb-explorer/Dockerfile
+++ b/applications/nwb-explorer/Dockerfile
@@ -36,8 +36,6 @@ WORKDIR $FOLDER
 RUN rm -rf /var/lib/apt/lists
 RUN apt-get update -qq && \
     apt-get install -y python3-tk vim nano unzip git g++ libjpeg-dev zlib1g-dev -qq 
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir cython
 
 RUN groupadd -g $NB_GID jovyan && \

--- a/applications/nwb-explorer/Dockerfile
+++ b/applications/nwb-explorer/Dockerfile
@@ -32,15 +32,7 @@ USER root
 
 WORKDIR $FOLDER
 
-RUN rm -rf /var/lib/apt/lists
-RUN apt-get update -qq &&\
-    apt-get install python3-tk vim nano unzip git g++ libjpeg-dev zlib1g-dev -qq
-RUN pip install cython --no-cache-dir
 
-RUN chown $NB_UID /opt
-RUN chown $NB_UID .
-
---------
 
 RUN rm -rf /var/lib/apt/lists
 

--- a/applications/nwb-explorer/Dockerfile
+++ b/applications/nwb-explorer/Dockerfile
@@ -56,7 +56,8 @@ RUN pip install -r requirements.txt --no-cache-dir
 COPY --from=clone $FOLDER .
 
 
-RUN mkdir -p /opt/workspace
+RUN mkdir -p /opt/workspace && \
+    chown -R $NB_UID:$NB_GID /opt/workspace
 RUN ln -s /opt/workspace workspace
 RUN mkdir -p /opt/home
 RUN python utilities/install.py --npm-skip --no-test


### PR DESCRIPTION
In the earlier version , I wasn't able to build the docker file locally as well . Upon carefully inspecting what and where the error arises from , I proposed the following changes :

+ Added a group **jovyan** and gave it ownership of the respective directories in order to allow the Docker image to build .

As for the workflow file , I was constantly getting this warning of Node.js version 12 being deprecated , so ended up making a new workflow file to further inspect this and upgrade it to the required Node.js version 16 .

Please let me know if the following approach is correct, if there are any changes or a different approach that is required altogether.