### PR TITLE
Feature/749

### DIFF
--- a/applications/osb-portal/src/components/common/MarkdownViewer.tsx
+++ b/applications/osb-portal/src/components/common/MarkdownViewer.tsx
@@ -16,6 +16,7 @@ import {
   radius,
 } from "../../theme";
 import { OSBRepository, RepositoryType } from "../../apiclient/workspaces";
+import { Workspace } from '../../types/workspace';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -132,7 +133,7 @@ export const MarkdownViewer = ({
   className,
 }: {
   text: string;
-  repository?: OSBRepository;
+  repository?: OSBRepository | Workspace;
   className?: string;
 }) => {
   const classes = useStyles();

--- a/applications/osb-portal/src/components/repository/RepositoryPageDetails.tsx
+++ b/applications/osb-portal/src/components/repository/RepositoryPageDetails.tsx
@@ -59,6 +59,7 @@ import Resources from "./resources";
 import { EditRepoDialog } from "..";
 import { UserInfo } from "../../types/user";
 import { canEditRepository } from "../../service/UserService";
+import { AboutOSBPaper } from "../styled/AboutOSBPaper";
 
 const RepoDetailsIconButton = styled(IconButton)(({ theme }) => ({
   "&:hover": {
@@ -120,14 +121,6 @@ const RepoDetailsBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
       },
     },
   },
-}));
-
-const AboutOSBPaper = styled(Paper)(({ theme }) => ({
-  padding: theme.spacing(2),
-  background: infoBoxBg,
-  borderRadius: inputRadius,
-  marginTop: theme.spacing(2),
-  overflow: "auto",
 }));
 
 const StyledViewButton = styled(Button)(({ theme }) => ({

--- a/applications/osb-portal/src/components/styled/AboutOSBPaper.tsx
+++ b/applications/osb-portal/src/components/styled/AboutOSBPaper.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+// components
+import Paper from "@mui/material/Paper";
+
+// style
+import {
+    infoBoxBg,
+    inputRadius
+} from "../../theme";
+import styled from "@mui/system/styled";
+
+
+export const AboutOSBPaper = styled(Paper)(({ theme }) => ({
+    padding: theme.spacing(2),
+    background: infoBoxBg,
+    borderRadius: inputRadius,
+    marginTop: theme.spacing(2),
+    overflow: "auto",
+  }));

--- a/applications/osb-portal/src/components/workspace/drawer/WorkspaceInteractions.tsx
+++ b/applications/osb-portal/src/components/workspace/drawer/WorkspaceInteractions.tsx
@@ -172,7 +172,7 @@ export default (props: WorkspaceProps | any) => {
   };
 
   React.useEffect(() => { 
-    if(!isWorkspaceWaiting(workspace) {
+    if(!isWorkspaceWaiting(workspace)) {
       refreshWorkspaceResources() }
    }, []);
 

--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -33,12 +33,14 @@ import WorkspaceDetailsInfo from "../components/workspace/WorkspaceDetailsInfo";
 import { canEditWorkspace } from "../service/UserService";
 
 //types
-import { Workspace, OSBApplication } from "../types/workspace";
+import { Workspace, OSBApplication } from '../types/workspace';
 
 //icons
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { AboutOSBPaper } from "../components/styled/AboutOSBPaper";
+import MarkdownViewer from "../components/common/MarkdownViewer";
 
 
 const NavbarButton = styled(Button)(({ theme }) => ({
@@ -293,16 +295,14 @@ export const WorkspacePage = (props: any) => {
                         )}
                       </Box>
                       {workspace?.thumbnail && <Divider />}
-                      <Typography
-                        variant="subtitle1"
-                        sx={{
-                          color: lightWhite,
-                          letterSpacing: "0.01em",
-                          lineHeight: "24px",
-                        }}
-                      >
-                        {workspace?.description}
-                      </Typography>
+                      <Box className="verticalFit">
+                        <AboutOSBPaper className={`verticalFit`}>
+                          <MarkdownViewer
+                            text={workspace?.description}
+                            repository={workspace}
+                          />
+                        </AboutOSBPaper>
+                      </Box>
                     </Stack>
                   </Box>
                 </Grid>

--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -11,8 +11,6 @@ import {
   bgDarkest,
   bgDark,
   lightWhite,
-  infoBoxBg,
-  inputRadius,
 } from "../theme";
 
 //components
@@ -22,7 +20,6 @@ import Grid from "@mui/material/Grid";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
-import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import Backdrop from "@mui/material/Backdrop";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -31,7 +28,6 @@ import { OSBSplitButton } from "../components/common/OSBSplitButton";
 import { WorkspaceActionsMenu } from "../components";
 
 import WorkspaceDetailsInfo from "../components/workspace/WorkspaceDetailsInfo";
-import MarkdownViewer from "../components/common/MarkdownViewer";
 
 //services
 import { canEditWorkspace } from "../service/UserService";
@@ -44,6 +40,7 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 
+
 const NavbarButton = styled(Button)(({ theme }) => ({
   fontSize: "12px",
   textTransform: "none",
@@ -53,14 +50,6 @@ const NavbarButton = styled(Button)(({ theme }) => ({
   "&:hover": {
     backgroundColor: "transparent",
   },
-}));
-
-const AboutOSBPaper = styled(Paper)(({ theme }) => ({
-  padding: theme.spacing(2),
-  background: infoBoxBg,
-  borderRadius: inputRadius,
-  marginTop: theme.spacing(2),
-  overflow: "auto",
 }));
 
 export const WorkspacePage = (props: any) => {
@@ -160,32 +149,34 @@ export const WorkspacePage = (props: any) => {
                   defaultSelected={workspace?.defaultApplication}
                   handleClick={openWithApp}
                 />
-
+                
                 <WorkspaceActionsMenu
                   workspace={workspace}
                   user={user}
                   isWorkspaceOpen={isWorkspaceOpen}
-                  ButtonComponent={(props) => (
-                    <NavbarButton
-                      {...props}
-                      size="small"
-                      variant="contained"
-                      aria-label="more"
-                      sx={{
-                        background: chipBg,
-                        boxShadow: "none",
-                        minWidth: "32px",
-                      }}
-                    >
-                      <MoreVertIcon fontSize="small" />
-                    </NavbarButton>
-                  )}
+                  ButtonComponent={(props) => (<NavbarButton
+                    {...props}
+                    
+                    size="small"
+                    variant="contained"
+                    aria-label="more"
+
+                    
+                    sx={{
+                      background: chipBg,
+                      boxShadow: "none",
+                      minWidth: "32px",
+                    }}
+                    
+                  >
+                    <MoreVertIcon fontSize="small" />
+                  </NavbarButton>)}
                 />
               </Grid>
             </Grid>
           </Box>
         </Box>
-        {!workspace || workspace?.id !== parseInt(workspaceId) ? (
+        {(!workspace || workspace?.id !== parseInt(workspaceId)) ? (
           <Box
             flex={1}
             px={2}
@@ -302,15 +293,7 @@ export const WorkspacePage = (props: any) => {
                         )}
                       </Box>
                       {workspace?.thumbnail && <Divider />}
-                      <Box className="verticalFit">
-                        <AboutOSBPaper className={`verticalFit`}>
-                          <MarkdownViewer
-                            text={workspace?.description}
-                            repository={workspace}
-                          />
-                        </AboutOSBPaper>
-                      </Box>
-                      {/* <Typography
+                      <Typography
                         variant="subtitle1"
                         sx={{
                           color: lightWhite,
@@ -319,7 +302,7 @@ export const WorkspacePage = (props: any) => {
                         }}
                       >
                         {workspace?.description}
-                      </Typography> */}
+                      </Typography>
                     </Stack>
                   </Box>
                 </Grid>
@@ -344,9 +327,7 @@ export const WorkspacePage = (props: any) => {
       )}
     </>
   ) : (
-    <Backdrop open={true}>
-      <CircularProgress />
-    </Backdrop>
+    <Backdrop open={true}><CircularProgress /></Backdrop>
   );
 };
 export default WorkspacePage;

--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -11,6 +11,8 @@ import {
   bgDarkest,
   bgDark,
   lightWhite,
+  infoBoxBg,
+  inputRadius,
 } from "../theme";
 
 //components
@@ -20,6 +22,7 @@ import Grid from "@mui/material/Grid";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
+import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import Backdrop from "@mui/material/Backdrop";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -28,6 +31,7 @@ import { OSBSplitButton } from "../components/common/OSBSplitButton";
 import { WorkspaceActionsMenu } from "../components";
 
 import WorkspaceDetailsInfo from "../components/workspace/WorkspaceDetailsInfo";
+import MarkdownViewer from "../components/common/MarkdownViewer";
 
 //services
 import { canEditWorkspace } from "../service/UserService";
@@ -40,7 +44,6 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 
-
 const NavbarButton = styled(Button)(({ theme }) => ({
   fontSize: "12px",
   textTransform: "none",
@@ -50,6 +53,14 @@ const NavbarButton = styled(Button)(({ theme }) => ({
   "&:hover": {
     backgroundColor: "transparent",
   },
+}));
+
+const AboutOSBPaper = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  background: infoBoxBg,
+  borderRadius: inputRadius,
+  marginTop: theme.spacing(2),
+  overflow: "auto",
 }));
 
 export const WorkspacePage = (props: any) => {
@@ -149,34 +160,32 @@ export const WorkspacePage = (props: any) => {
                   defaultSelected={workspace?.defaultApplication}
                   handleClick={openWithApp}
                 />
-                
+
                 <WorkspaceActionsMenu
                   workspace={workspace}
                   user={user}
                   isWorkspaceOpen={isWorkspaceOpen}
-                  ButtonComponent={(props) => (<NavbarButton
-                    {...props}
-                    
-                    size="small"
-                    variant="contained"
-                    aria-label="more"
-
-                    
-                    sx={{
-                      background: chipBg,
-                      boxShadow: "none",
-                      minWidth: "32px",
-                    }}
-                    
-                  >
-                    <MoreVertIcon fontSize="small" />
-                  </NavbarButton>)}
+                  ButtonComponent={(props) => (
+                    <NavbarButton
+                      {...props}
+                      size="small"
+                      variant="contained"
+                      aria-label="more"
+                      sx={{
+                        background: chipBg,
+                        boxShadow: "none",
+                        minWidth: "32px",
+                      }}
+                    >
+                      <MoreVertIcon fontSize="small" />
+                    </NavbarButton>
+                  )}
                 />
               </Grid>
             </Grid>
           </Box>
         </Box>
-        {(!workspace || workspace?.id !== parseInt(workspaceId)) ? (
+        {!workspace || workspace?.id !== parseInt(workspaceId) ? (
           <Box
             flex={1}
             px={2}
@@ -293,7 +302,15 @@ export const WorkspacePage = (props: any) => {
                         )}
                       </Box>
                       {workspace?.thumbnail && <Divider />}
-                      <Typography
+                      <Box className="verticalFit">
+                        <AboutOSBPaper className={`verticalFit`}>
+                          <MarkdownViewer
+                            text={workspace?.description}
+                            repository={workspace}
+                          />
+                        </AboutOSBPaper>
+                      </Box>
+                      {/* <Typography
                         variant="subtitle1"
                         sx={{
                           color: lightWhite,
@@ -302,7 +319,7 @@ export const WorkspacePage = (props: any) => {
                         }}
                       >
                         {workspace?.description}
-                      </Typography>
+                      </Typography> */}
                     </Stack>
                   </Box>
                 </Grid>
@@ -327,7 +344,9 @@ export const WorkspacePage = (props: any) => {
       )}
     </>
   ) : (
-    <Backdrop open={true}><CircularProgress /></Backdrop>
+    <Backdrop open={true}>
+      <CircularProgress />
+    </Backdrop>
   );
 };
 export default WorkspacePage;


### PR DESCRIPTION
- view markdown viewer on workspace page
- make a common styled component for AboutOSBPaper to be used in both repository and workspace page

<img width="874" alt="Screenshot 2023-06-29 at 4 07 11 PM" src="https://github.com/OpenSourceBrain/OSBv2/assets/32265731/44772d96-4f8e-4a2f-b8e1-f4bbb1916adb">
