### PR TITLE
Feature/776 - Add "Manage running workspaces" button on user account page

### DIFF
--- a/applications/osb-portal/src/pages/UserPage.tsx
+++ b/applications/osb-portal/src/pages/UserPage.tsx
@@ -44,6 +44,7 @@ import { UserInfo } from "../types/user";
 import RepositoriesTable from "../components/repository/RespositoriesTable";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { IconButton } from "@mui/material";
+import { getNotebooksNamedServerLink } from "../utils";
 
 const styles = {
   profileInformation: (theme) => ({
@@ -295,6 +296,14 @@ export const UserPage = (props: any) => {
 
   const onGroupClick = (groupname) => {
     navigate(`/user/${user.username}/groups/${groupname}`);
+  }
+
+  const navigateToNotebookNamedServerLink = () => {
+    const serverlink = getNotebooksNamedServerLink()
+    if (serverlink) {
+      window.open(serverlink, "_blank");
+    }
+    return
   }
 
   const canEdit =
@@ -604,7 +613,15 @@ export const UserPage = (props: any) => {
                   }
                 </Box>
               }
-
+              {canEdit && (
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  onClick={() => navigateToNotebookNamedServerLink()}
+                >
+                  Manage running workspaces
+                </Button>
+              )}
 
 
               {user.registrationDate && (

--- a/applications/osb-portal/src/pages/UserPage.tsx
+++ b/applications/osb-portal/src/pages/UserPage.tsx
@@ -15,6 +15,7 @@ import LinkIcon from "@mui/icons-material/Link";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import TwitterIcon from "@mui/icons-material/Twitter";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import LanguageIcon from "@mui/icons-material/Language";
 import GroupIcon from "@mui/icons-material/Group";
 import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
@@ -610,18 +611,26 @@ export const UserPage = (props: any) => {
                           {user.quotas[row]} {USER_QUOTAS[row].showGB && "GB"}
                         </Typography>
                       </Box>)
-                  }
+                    }
+                    {canEdit && (
+                      <Button
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "flex-start",
+                          textTransform: "capitalize",
+                          padding: "10px 0 0 0",
+                          textAlign: "left",
+                          "&:hover": { backgroundColor: "transparent" },
+                        }}
+                        endIcon={<OpenInNewIcon />}
+                        onClick={() => navigateToNotebookNamedServerLink()}
+                      >
+                        Manage running workspaces
+                      </Button>
+                    )}
                 </Box>
               }
-              {canEdit && (
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  onClick={() => navigateToNotebookNamedServerLink()}
-                >
-                  Manage running workspaces
-                </Button>
-              )}
 
 
               {user.registrationDate && (

--- a/applications/osb-portal/src/utils.ts
+++ b/applications/osb-portal/src/utils.ts
@@ -1,4 +1,4 @@
-import { OSBApplication } from "./types/workspace";
+import { OSBApplication, OSBApplications as OSBAllApplications } from "./types/workspace";
 
 declare var window: any;
 
@@ -23,4 +23,13 @@ export function getApplicationDomain(app: OSBApplication) {
     return null;
   }
   return `${app.subdomain}.${getBaseDomain()}`
+}
+
+
+export function getNotebooksNamedServerLink() {
+  // Wouldn't work for localhost
+  if (window.location.host.includes("localhost")) {
+    return null;
+  }
+  return `${OSBAllApplications.jupyter.subdomain}.${getBaseDomain()}/hub/home`
 }


### PR DESCRIPTION
Task link - https://github.com/OpenSourceBrain/OSBv2/issues/776

Task description:
- Adding a button "Manage running workspaces" 
- When pressed:
    -> If in localhost doesn't do anything (no subdomain), 
    -> If in osb.local or other like v2.opensourcebrain.org, pushes to ->  notebooks.{domain}/hub/home (setting notebooks as the subdomain and adding path after.


<img width="254" alt="image" src="https://github.com/OpenSourceBrain/OSBv2/assets/59233227/e7d8616e-f4e1-4a69-aed4-ced55426381f">
