### PR TITLE
769 Add resources to workspace dialog - buttons not shown properly

### DIFF
--- a/applications/osb-portal/src/components/workspace/AddResourceForm.tsx
+++ b/applications/osb-portal/src/components/workspace/AddResourceForm.tsx
@@ -228,6 +228,12 @@ const styles = {
         padding: "0.6rem",
       },
     },
+    "& .MuiTable-root": {
+      tableLayout: 'fixed'
+    },
+    "& .MuiTypography-h5": {
+      wordWrap: 'break-word'
+    }
   },
 };
 

--- a/applications/osb-portal/src/components/workspace/WorkspaceFromRepository.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceFromRepository.tsx
@@ -301,6 +301,12 @@ export const WorkspaceFromRepository = ({
                     width: 2,
                     height: 2,
                   },
+                  "& .MuiTable-root": {
+                    tableLayout: 'fixed'
+                  },
+                  "& .MuiTypography-h5": {
+                    wordWrap: 'break-word'
+                  }
                 }}
               >
                 <Repositories


### PR DESCRIPTION
Issue #769 
Problem: Add resources to workspace dialog - buttons not shown properly
Solution: 
I added table layout property to be fixed so it will be fixed according to table container component, also made these changes only for 'Add resources to Workspace' dialog window as others are not reflecting this problem
Also added 'break-word' value to the title so it will not overflow.

<img width="1078" alt="image" src="https://github.com/OpenSourceBrain/OSBv2/assets/67194168/5e7d3f0f-e1e1-4cd2-9083-a9484d398b75">
