### PR TITLE
Feature/828 - Workspace and repositories search and filter refactor

### DIFF
--- a/applications/osb-portal/src/pages/WorkspacesPage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacesPage.tsx
@@ -88,9 +88,6 @@ export const WorkspacesPage = (props: WorkspacesPageProps) => {
     setSearchFilterValues({
       ...searchFilterValues,
       text: newTextFilter,
-      tags: newTextFilter
-        ? [...searchFilterValues?.tags, newTextFilter]
-        : searchFilterValues?.tags,
     });
   }, 500);
 

--- a/applications/osb-portal/src/service/RepositoryService.tsx
+++ b/applications/osb-portal/src/service/RepositoryService.tsx
@@ -108,7 +108,7 @@ class RepositoryService {
     return this.workspacesApi.osbrepositoryGet({
       page,
       perPage: size,
-      q: `user_id=${userId}`,
+      userId: userId
     });
   }
 

--- a/applications/osb-portal/src/service/RepositoryService.tsx
+++ b/applications/osb-portal/src/service/RepositoryService.tsx
@@ -18,7 +18,7 @@ type RepositoriesListAndPaginationDetails = InlineResponse2001;
 
 const workspacesApiUri = "/proxy/workspaces/api";
 
-const PER_PAGE_DEFAULT = 18;
+const PER_PAGE_DEFAULT = 24;
 
 class RepositoryService {
   workspacesApi: RestApi = null;

--- a/applications/osb-portal/src/service/WorkspaceService.tsx
+++ b/applications/osb-portal/src/service/WorkspaceService.tsx
@@ -124,6 +124,7 @@ class WorkspaceService {
 
     if (filter.text) {
       params.name__like = filter.text;
+      params.description__like = filter.text;
     }
 
     if (filter.user_id) {

--- a/applications/workspaces/server/workspaces/persistence/crud_persistence.py
+++ b/applications/workspaces/server/workspaces/persistence/crud_persistence.py
@@ -127,14 +127,12 @@ class OSBRepositoryRepository(BaseModelRepository, OwnerModel):
 
     def search_qs(self, filter=None, q=None, tags=None, types=None, user_id=None):
         q_base = self.model.query
-        if user_id is not None:
-            q_base = q_base.filter_by(user_id=user_id)
-
         if filter is None:
             if tags:
                 q_base = self.filter_by_tags(tags, q_base)
         else:
-            q_base = self.filter_by_name_summary(filter, q_base)
+            # qfilter handles the search by name, summary, and user_id
+            q_base = self.filter_by_qfilters(filter, q_base)
             q_base = self.filter_by_search_tags(filter, q_base)
             if tags:
                 q_base = q_base.intersect(self.filter_by_tags(tags, q_base))
@@ -145,7 +143,7 @@ class OSBRepositoryRepository(BaseModelRepository, OwnerModel):
 
         return q_base.order_by(desc(OSBRepositoryEntity.timestamp_updated))
 
-    def filter_by_name_summary(self, filter, q_base):
+    def filter_by_qfilters(self, filter, q_base):
         q_base = q_base.filter(
             or_(*[self._create_filter(*f) for f in filter]))
         return q_base

--- a/applications/workspaces/server/workspaces/persistence/crud_persistence.py
+++ b/applications/workspaces/server/workspaces/persistence/crud_persistence.py
@@ -157,7 +157,7 @@ class OSBRepositoryRepository(BaseModelRepository, OwnerModel):
 
     def filter_by_search_tags(self, filter, q_base):
         search_tags = self.tags_from_search(filter)
-        q_base = q_base.union(self.model.query.join(self.model.tags).filter(
+        q_base = q_base.union(q_base.join(self.model.tags).filter(
             func.lower(Tag.tag).in_(func.lower(t) for t in search_tags.split("+"))))
         return q_base
 

--- a/applications/workspaces/server/workspaces/persistence/crud_persistence.py
+++ b/applications/workspaces/server/workspaces/persistence/crud_persistence.py
@@ -52,36 +52,63 @@ class WorkspaceRepository(BaseModelRepository, OwnerModel):
 
     def search_qs(self, filter=None, q=None, tags=None, user_id=None, show_all=False, *args, **kwargs):
         q_base = self.model.query
+        q_base = self.filter_by_user_and_fieldkey(
+            filter, user_id, show_all, q_base)
 
+        if filter is None:
+            if tags:
+                q_base = self.filter_by_tags(tags, q_base)
+        else:
+            q_base = self.filter_by_name_description(filter, q_base)
+            q_base = self.filter_by_search_tags(filter, q_base)
+
+            if tags:
+                q_base = q_base.intersect(self.filter_by_tags(tags, q_base))
+
+            q_base = q_base.filter(
+                *[self._create_filter(*f) for f in filter if f[0].key != "name"])
+
+        return q_base.order_by(desc(WorkspaceEntity.timestamp_updated))
+
+    def filter_by_user_and_fieldkey(self, filter, user_id, show_all, q_base):
         if filter and any(field for field, condition, value in filter if field.key == "publicable" and value):
             pass
         elif user_id is not None:
             # Admins see all workspaces, non admin users can see only their own workspaces or shared with them
             if not show_all:
                 q_base = q_base.filter_by(user_id=user_id)
-                q_base = q_base.union(q_base.filter(
+                q_base = q_base.union(self.model.query.filter(
                     WorkspaceEntity.collaborators.any(user_id=user_id)))
             else:
                 q_base = q_base
         else:
             # No logged in user, show only public (in case was not specified)
             q_base = q_base.filter(WorkspaceEntity.publicable == True)
+        return q_base
 
+    def filter_by_tags(self, tags, q_base):
+        q_base = q_base.join(self.model.tags).filter(
+            func.lower(Tag.tag).in_(func.lower(t) for t in tags.split("+")))
+        return q_base
 
-        if filter is not None:
-            if tags:
-                q_base = q_base.filter(
-                    *[self._create_filter(*f) for f in filter if f[0].key == "name"] )
-                q_base = q_base.intersect(self.model.query.join(self.model.tags).filter(
-                    func.lower(Tag.tag).in_(func.lower(t) for t in tags.split("+"))))
-           
-            q_base = q_base.filter(
-                    *[self._create_filter(*f) for f in filter if f[0].key != "name"])
-        elif tags:
-            q_base = q_base.join(self.model.tags).filter(
-                func.lower(Tag.tag).in_(func.lower(t) for t in tags.split("+")))
+    def filter_by_search_tags(self, filter, q_base):
+        search_tags = self.tags_from_search(filter)
+        q_base = q_base.union(q_base.join(self.model.tags).filter(
+            func.lower(Tag.tag).in_(func.lower(t) for t in search_tags.split("+"))))
 
-        return q_base.order_by(desc(WorkspaceEntity.timestamp_updated))
+        return q_base
+
+    def tags_from_search(self, filter):
+        tags = ''
+        for field, condition, value in filter:
+            if field.key == "name":
+                tags = value.replace("+", "").replace("%", "")
+                break
+        return tags
+
+    def filter_by_name_description(self, filter, q_base):
+        return q_base.filter(
+            or_(*[self._create_filter(*f) for f in filter if (f[0].key == "name" or f[0].key == "description")]))
 
     def delete(self, id):
         super().delete(id)
@@ -100,20 +127,47 @@ class OSBRepositoryRepository(BaseModelRepository, OwnerModel):
 
     def search_qs(self, filter=None, q=None, tags=None, types=None, user_id=None):
         q_base = self.model.query
-        if tags:
-            q_base = q_base.join(self.model.tags).filter(
-                Tag.tag.in_(tags.split("+")))
-        if filter:
-            q_base = q_base.filter(
-                or_(*[self._create_filter(*f) for f in filter]))
+        if user_id is not None:
+            q_base = q_base.filter_by(user_id=user_id)
+
+        if filter is None:
+            if tags:
+                q_base = self.filter_by_tags(tags, q_base)
+        else:
+            q_base = self.filter_by_name_summary(filter, q_base)
+            q_base = self.filter_by_search_tags(filter, q_base)
+            if tags:
+                q_base = q_base.intersect(self.filter_by_tags(tags, q_base))
 
         if types is not None:
             q_base = q_base.filter(
                 or_(self.model.content_types.ilike(f"%{t}%") for t in types.split("+")))
 
-        if user_id is not None:
-            q_base = q_base.filter_by(user_id=user_id)
         return q_base.order_by(desc(OSBRepositoryEntity.timestamp_updated))
+
+    def filter_by_name_summary(self, filter, q_base):
+        q_base = q_base.filter(
+            or_(*[self._create_filter(*f) for f in filter]))
+        return q_base
+
+    def filter_by_tags(self, tags, q_base):
+        q_base = q_base.join(self.model.tags).filter(
+            func.lower(Tag.tag).in_(func.lower(t) for t in tags.split("+")))
+        return q_base
+
+    def filter_by_search_tags(self, filter, q_base):
+        search_tags = self.tags_from_search(filter)
+        q_base = q_base.union(self.model.query.join(self.model.tags).filter(
+            func.lower(Tag.tag).in_(func.lower(t) for t in search_tags.split("+"))))
+        return q_base
+
+    def tags_from_search(self, filter):
+        tags = ''
+        for field, condition, value in filter:
+            if field.key == "name":
+                tags = value.replace("+", "").replace("%", "")
+                break
+        return tags
 
 
 class VolumeStorageRepository(BaseModelRepository):

--- a/applications/workspaces/server/workspaces/persistence/crud_persistence.py
+++ b/applications/workspaces/server/workspaces/persistence/crud_persistence.py
@@ -127,11 +127,13 @@ class OSBRepositoryRepository(BaseModelRepository, OwnerModel):
 
     def search_qs(self, filter=None, q=None, tags=None, types=None, user_id=None):
         q_base = self.model.query
+        if user_id is not None:
+            q_base = q_base.filter_by(user_id=user_id)
+
         if filter is None:
             if tags:
                 q_base = self.filter_by_tags(tags, q_base)
         else:
-            # qfilter handles the search by name, summary, and user_id
             q_base = self.filter_by_qfilters(filter, q_base)
             q_base = self.filter_by_search_tags(filter, q_base)
             if tags:


### PR DESCRIPTION
Issue related - #828 

Task description

Implementation for the `search` and `filter by tags` do the following:

1. First - Search the text in the search bar → This returns the list of workspaces/repos that have - either one or all - of the titles/summary/tags associated with them.
2. Then, search for the tags that are set from the filters. From the result in (1) above, we return only the ones that have the tags selected from here (2).

Tags are now searched from the search bar - for both Repositories and Workspace - if they match any tags. This implementation is now in BE. And has been removed from Workspace FE (where it was added to the tags argument to pass to BE).

After this implementation:
- The search and tags field works the same for both workspace and repos. 
- Also, the tag bug is removed now = on each text stroke tag gets added to the tags filter.
- Repositories default per_page changed to 24 as well.

