### PR TITLE
feature/435 - add confirmation dialog for Repository delete

### DIFF
--- a/applications/osb-portal/src/components/dialogs/DeleteDialog.tsx
+++ b/applications/osb-portal/src/components/dialogs/DeleteDialog.tsx
@@ -12,15 +12,17 @@ import { Button } from "@mui/material";
 const DeleteDialog = ({
 	open,
 	setOpen,
-	workspace,
-	handleDeleteWorkspace,
+	title,
+	description,
+	handleDeleteCallback,
+	navigateToPath
 }) => {
 	const navigate = useNavigate();
 
 	const handleDelete = () => {
-		handleDeleteWorkspace();
-		if (window.location.pathname !== "/") {
-			navigate("/");
+		handleDeleteCallback();
+		if (navigateToPath && window.location.pathname !== "/") {
+			navigate(navigateToPath)
 		}
 	}
 
@@ -29,8 +31,8 @@ const DeleteDialog = ({
 			open={open}
 			onClose={() => setOpen(false)}
 		>
-			<DialogTitle>{'Delete Workspace "' + workspace.name + '"'}</DialogTitle>
-			<DialogContent>{'You are about to delete Workspace "' + workspace.name + '". This action cannot be undone. Are you sure?'}</DialogContent>
+			<DialogTitle>{title}</DialogTitle>
+			<DialogContent>{description}</DialogContent>
 			<DialogActions>
 				<Button
 					color="primary"

--- a/applications/osb-portal/src/components/repository/RepositoryActionsMenu.tsx
+++ b/applications/osb-portal/src/components/repository/RepositoryActionsMenu.tsx
@@ -16,6 +16,8 @@ import { styled } from "@mui/styles";
 import { chipBg } from "../../theme";
 import IconButton from "@mui/material/IconButton";
 import RepositoryService from "../../service/RepositoryService";
+import DeleteDialog from "../dialogs/DeleteDialog";
+
 
 interface RepositoryActionsMenuProps {
   repository: OSBRepository;
@@ -37,6 +39,7 @@ const ThreeDotButton = styled(Button)(({ theme }) => ({
 export default (props: RepositoryActionsMenuProps) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [repositoryEditorOpen, setRepositoryEditorOpen] = React.useState(false);
+  const [showDeleteRepositoryDialog, setShowDeleteRepositoryDialog] = React.useState(false);
 
   const canEdit = canEditRepository(props.user, props.repository);
   const navigate = useNavigate();
@@ -96,7 +99,10 @@ export default (props: RepositoryActionsMenuProps) => {
         {canEdit && (
         <MenuItem
               className="open-repository"
-              onClick={handleDeleteRepository}
+            onClick={() => {
+              setShowDeleteRepositoryDialog(true);
+              setAnchorEl(null);
+            }}
             >
               Delete
             </MenuItem>
@@ -113,6 +119,19 @@ export default (props: RepositoryActionsMenuProps) => {
           repository={props.repository}
         />
       )}
+
+      {
+        showDeleteRepositoryDialog && (
+          <DeleteDialog
+            open={showDeleteRepositoryDialog}
+            setOpen={setShowDeleteRepositoryDialog}
+            handleDeleteCallback={handleDeleteRepository}
+            navigateToPath={'/repositories'}
+            title={'Delete Repository "' + props.repository.name + '"'}
+            description={'You are about to delete Repository "' + props.repository.name + '". This action cannot be undone. Are you sure?'}
+          />
+        )
+      }
     </>
   );
 };

--- a/applications/osb-portal/src/components/workspace/WorkspaceActionsMenu.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceActionsMenu.tsx
@@ -272,8 +272,10 @@ export default (props: WorkspaceActionsMenuProps) => {
             <DeleteDialog
               open={showDeleteWorkspaceDialog}
               setOpen={setShowDeleteWorkspaceDialog}
-              handleDeleteWorkspace={handleDeleteWorkspace}
-              workspace={props.workspace}
+              handleDeleteCallback={handleDeleteWorkspace}
+              navigateToPath="/"
+              title={'Delete Workspace "' + props.workspace.name + '"'}
+              description={'You are about to delete Workspace "' + props.workspace.name + '". This action cannot be undone. Are you sure?'}
             />
           )
         }


### PR DESCRIPTION
Task description:
Closes: #435 
- This PR adds confirmation dialog for deleting a repository ...
- Requirement of `the edit and delete option should be available only to the owner or administrator` was already met. 


Looks as follows:
![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/4805e9e0-4f2e-4a33-8ad1-83430af0ded6)


