### PR TITLE
#808 The 'Add selection to existing workspace' and ' New workspace from selection' do not stay enabled when you cancel the new workspace creation

### DIFF
--- a/applications/osb-portal/src/components/repository/RepositoryPageDetails.tsx
+++ b/applications/osb-portal/src/components/repository/RepositoryPageDetails.tsx
@@ -140,12 +140,16 @@ const RepositoryPageDetails = ({
   checkedChanged,
   user,
   onAction,
+  resetChecked,
+  setResetChecked
 }: {
   repository: OSBRepository;
   openRepoUrl: () => void;
   checkedChanged: (checked: RepositoryResourceNode[]) => any;
   user: UserInfo;
   onAction: (r: OSBRepository) => void;
+  resetChecked: boolean;
+  setResetChecked: (value: boolean) => any;
 }) => {
   const [currentPath, setCurrentPath] = React.useState<
     RepositoryResourceNode[]
@@ -182,6 +186,7 @@ const RepositoryPageDetails = ({
     }
     setChecked({ ...checked });
     checkedChanged(Object.values(checked));
+    setResetChecked(false);
   };
 
   const addToCurrentPath = (n: RepositoryResourceNode) => {
@@ -192,8 +197,10 @@ const RepositoryPageDetails = ({
     if (value) {
       setChecked(resourcesListObject);
       checkedChanged(resourcesList);
+      setResetChecked(false);
     } else {
       setChecked({});
+      checkedChanged([])
     }
   };
 
@@ -208,6 +215,12 @@ const RepositoryPageDetails = ({
   const handleCloseDialog = () => {
     setRepositoryEditorOpen(false);
   };
+
+  React.useEffect(() => {
+    if(resetChecked){
+      setChecked({})
+    }
+  },[resetChecked])
 
   return (
     repository && (

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -128,6 +128,7 @@ export const RepositoryPage = (props: any) => {
     if (showWorkspaceEditor) {
       setChecked([]);
       setRefresh(!refresh);
+      setResetChecked(true);
     }
   };
 

--- a/applications/osb-portal/src/pages/RepositoryPage.tsx
+++ b/applications/osb-portal/src/pages/RepositoryPage.tsx
@@ -109,6 +109,7 @@ export const RepositoryPage = (props: any) => {
   const [workspaceLink, setWorkspaceLink] = React.useState(null);
   const [error, setError] = React.useState<any>(null);
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const [resetChecked, setResetChecked] = React.useState<boolean>(false);
 
   const canEdit = canEditRepository(props.user, props.repository);
   const [createdWorkspaceConfirmationContent, setCreatedWorkspaceConfirmationContent] = React.useState({
@@ -135,6 +136,7 @@ export const RepositoryPage = (props: any) => {
     if (showExistingWorkspaceEditor) {
       setChecked([]);
       setRefresh(!refresh);
+      setResetChecked(true);
     }
   };
 
@@ -401,6 +403,8 @@ export const RepositoryPage = (props: any) => {
               r && setRepository({ ...repository, ...r })
             }
             user={user}
+            resetChecked={resetChecked}
+            setResetChecked={setResetChecked}
           />
         </>
       )}


### PR DESCRIPTION
Issue #808 
Problem: The 'Add selection to existing workspace' and ' New workspace from selection' do not stay enabled when you cancel the new workspace creation https://github.com/OpenSourceBrain/OSBv2/issues/808
Solution: 
Added variable to check if 'Cancel' button is clicked, which later reset checked state in RepositoryPageDetails to be empty


https://github.com/OpenSourceBrain/OSBv2/assets/67194168/646665b6-cec4-42c9-bcad-e8c085f5d261


