### PR TITLE
feature/816 - "go to workspace" dialog for Create a new NWB workspace, and others

### DIFF
--- a/applications/osb-portal/src/components/workspace/NewWorkspaceItem.tsx
+++ b/applications/osb-portal/src/components/workspace/NewWorkspaceItem.tsx
@@ -183,7 +183,7 @@ export const NewWorkspaceItem = (props: ItemProps) => {
     }
   };
 
-  // default workspace - other - computational modeling, data analysis, interactive development
+  // default workspace - other - computational modeling (NETPYNE), data analysis (NWB Explorer), interactive development (JupyterLab)
   // non default workspace - Create new workspace from repository
   const defaultWorkspace: Workspace = WORKSPACE_TEMPLATES[template];
   return (


### PR DESCRIPTION

Task description:
Closes #816 

Adding the "Go to workspace" dialog for the other three modes of creating workspace.

Before the PR: the dialog existed only for - Create a new "workspace from repository" option. 
This PR: Adds the same dialog for other 3 i.e. - computational modeling (NETPYNE), data analysis (NWB Explorer), interactive development (JupyterLab).


https://github.com/OpenSourceBrain/OSBv2/assets/59233227/a31efe13-9a4c-4b2e-9905-694c6a6a7b6f



