### PR TITLE
#810 fix: remove the thumbnail after submit in workspaceEditor Dialog

### DIFF
--- a/applications/osb-portal/src/components/workspace/WorkspaceEditor.tsx
+++ b/applications/osb-portal/src/components/workspace/WorkspaceEditor.tsx
@@ -179,6 +179,7 @@ export default (props: WorkspaceEditProps) => {
             () => props.onLoadWorkspace(true, returnedWorkspace),
             (e) => console.error("Error uploading thumbnail", e)
           );
+          setThumbnail(null);
         } else {
           setLoading(true);
           props.onLoadWorkspace(true, returnedWorkspace);


### PR DESCRIPTION
This PR closes #810 and addresses two problems from the issue:
1. Solve the bug by - setting the thumbnail as `null` in the workspace Editor Dialog after submit 
2. Also addresses the issues mentioned in the comments. That is the correction to - "seeing old thumbnail when Editing workspace"