### PR TITLE
Feature/793 - non existent pages + private workspace

### DIFF
--- a/applications/osb-portal/src/App.tsx
+++ b/applications/osb-portal/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import Box from "@mui/material/Box";
 import { UserInfo } from "./types/user";
 import SampleIframePage from "./pages/SampleIframePage";
+import NotFoundPage from "./pages/NotFoundPage";
 
 declare module "@mui/styles/defaultTheme" {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -75,7 +76,7 @@ export const App = (props: AppProps) => {
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
-        <OSBErrorBoundary>
+        <OSBErrorBoundary error={props.error} >
           <CssBaseline />
           <AboutDialog />
           {!props.error && (
@@ -171,6 +172,7 @@ export const App = (props: AppProps) => {
                       />
                     }
                   />
+                  <Route path="*" element={<NotFoundPage />} />
                 </Routes>
               </Box>
             </Router>

--- a/applications/osb-portal/src/components/handlers/OSBErrorBoundary.tsx
+++ b/applications/osb-portal/src/components/handlers/OSBErrorBoundary.tsx
@@ -68,7 +68,7 @@ class OSBErrorBoundary extends React.Component<OSBErrorBoundaryProps, OwnState> 
     if (nextProps.error) {
       return { ...prevState, hasError: 'true', message: nextProps.error };
     }
-    return null;
+    return { ...prevState };
   }
 
   render() {

--- a/applications/osb-portal/src/components/handlers/OSBErrorBoundary.tsx
+++ b/applications/osb-portal/src/components/handlers/OSBErrorBoundary.tsx
@@ -7,6 +7,10 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Button from "@mui/material/Button";
 
+interface OSBErrorBoundaryProps {
+  error?: any;
+}
+
 interface OwnState {
   eventId: string;
   hasError: string;
@@ -23,9 +27,12 @@ const ERROR_MESSAGES: any = {
   // 404
   "NOT FOUND":
     "Oops. This resource could not be found. Please check the URL you are trying to access and try again.",
+  // User 404
+  "USER_NOT_FOUND":
+    "Oops. This user could not be found. Please check the URL you are trying to access and try again.",
 };
 
-class OSBErrorBoundary extends React.Component<{}, OwnState> {
+class OSBErrorBoundary extends React.Component<OSBErrorBoundaryProps, OwnState> {
   public state: OwnState = {
     eventId: null,
     hasError: null,
@@ -46,13 +53,22 @@ class OSBErrorBoundary extends React.Component<{}, OwnState> {
 
       let message =
         "Oops. Something went wrong. Please report this error to us.";
-      if (error.status && error.status < 500) {
+      if (window.location.pathname.startsWith("/user/")) {
+        message = ERROR_MESSAGES["USER_NOT_FOUND"];
+      } else if (error.status && error.status < 500) {
         message = ERROR_MESSAGES[error.statusText] || error.statusText;
       } else {
         Sentry.captureException(error);
       }
       this.setState({ ...this.state, message });
     });
+  }
+
+  static getDerivedStateFromProps(nextProps: any, prevState: any) {
+    if (nextProps.error) {
+      return { ...prevState, hasError: 'true', message: nextProps.error };
+    }
+    return null;
   }
 
   render() {

--- a/applications/osb-portal/src/pages/NotFoundPage.tsx
+++ b/applications/osb-portal/src/pages/NotFoundPage.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material'
+import { getCleanPath } from '../utils'
+
+const NotFoundPage = () => {
+	const [message, setMessage] = React.useState("")
+	const pathParts = getCleanPath(window.location.pathname)
+	React.useEffect(() => {
+		setMessage("This path doesn't exist")
+	}, [pathParts])
+	return (
+		<>
+			<Dialog open={true}>
+				<DialogTitle id="alert-dialog-title" title="Error" />
+				<DialogContent>
+					<Alert severity="error" key={1}>
+						<div className="errorAlertDiv" key={"div-1"}>
+							{message}
+						</div>
+					</Alert>
+				</DialogContent>
+				<DialogActions>
+					<Button
+						onClick={() => window.history.back()}
+					>
+						Go back
+					</Button>
+					<Button
+						variant="outlined"
+						color="primary"
+						onClick={() => window.open("/", "_self")}
+					>
+						Return to homepage
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</>
+	)
+
+
+}
+
+export default NotFoundPage

--- a/applications/osb-portal/src/pages/UserPage.tsx
+++ b/applications/osb-portal/src/pages/UserPage.tsx
@@ -182,7 +182,8 @@ export const UserPage = (props: any) => {
   React.useEffect(() => {
     getUser(userName).then((u) => {
       setUser(u);
-
+    }).catch((e) => {
+      setError(e);
     });
   }, [userName, props.workspacesCounter]);
 

--- a/applications/osb-portal/src/utils.ts
+++ b/applications/osb-portal/src/utils.ts
@@ -33,3 +33,11 @@ export function getNotebooksNamedServerLink() {
   }
   return `//${OSBAllApplications.jupyter.subdomain}.${getBaseDomain()}/hub/home`
 }
+
+export function getCleanPath(path: string) {
+  const pathParts = path.split("/")
+  if (pathParts[pathParts.length - 1] === "") {
+    pathParts.pop()
+  }
+  return pathParts
+}

--- a/applications/workspaces/server/workspaces/service/crud_service.py
+++ b/applications/workspaces/server/workspaces/service/crud_service.py
@@ -237,6 +237,8 @@ class WorkspaceService(BaseModelService):
 
     def is_authorized(self, workspace):
         current_user_id = keycloak_user_id()
+        if not current_user_id:
+            return False
         return workspace and (workspace.publicable or
                               (workspace.user_id and workspace.user_id == current_user_id) or
                               (get_auth_client().user_has_realm_role(user_id=current_user_id, role="administrator")))
@@ -299,6 +301,8 @@ class WorkspaceService(BaseModelService):
     def get(self, id_):
 
         workspace: Workspace = super().get(id_)
+        if not self.is_authorized(workspace):
+            raise NotAuthorized()
 
         if any(wr.status == ResourceStatus.P for wr in workspace.resources):
             fake_path = f"Importing resources"


### PR DESCRIPTION
Closes - #739, #793, and incognito mode (without token) correction.

This PR changes the blank screen with the Popup as image shown below.
Created 
- Incognito correction in Backend
- Non Existing pages correction by adding NotFoundPages for all wrong URL and 
    - Correcting ErrorBoundary for User Page error not showing
    - Showing Error for Workspace from props.error 


<br>

Video describing the Incognito fix:

https://github.com/OpenSourceBrain/OSBv2/assets/59233227/4c333f91-a67d-4a7d-b3ec-7d29a1abce41




<br>
<br>
<br>


Image sample:
<br>

![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/e373f9e4-a500-4b12-8d1d-2fa73f1ff9e9)
![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/a1f20d12-3194-47b4-a2da-f2f530bccab3)
![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/45b5691c-9f62-4a73-97bf-678c1ba60407)
![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/70e0221c-dd15-47a5-84d7-571ff7df2ce2)

