### PR TITLE
Feature/841 - ignore .ipynb_checkpoints folder when parsing for resources in workspace

### DIFF
--- a/applications/workspaces/tasks/scan-workspace/main.py
+++ b/applications/workspaces/tasks/scan-workspace/main.py
@@ -29,6 +29,8 @@ logger.info(f"Scanning folder: {folder}, workspace id: {workspace_id}, queue: {q
 # notify_queue(queue, message)
 resources = []
 for root, dirs, files in os.walk(folder):
+    if ".ipynb_checkpoints" in root:
+        continue
     for file in files:
         full_file_name = os.path.join(root, file)
         filename, file_extension = os.path.splitext(full_file_name)


### PR DESCRIPTION
Closes - #841 

Task description: 
- Any files that are inside .ipynb_checkpoints will be ignored.

<br>

Tested as following

The following is the folder structure for the repository the workspace was created from.

<img width="228" alt="image" src="https://github.com/OpenSourceBrain/OSBv2/assets/59233227/11d96f79-b567-4028-b13a-9aeb4ef6e907">


![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/9034a4ef-c44c-4635-9f60-9712a9eb568e)

<br>
<br>

Before the changes was: The .ipynb_checkpoints are included here.

![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/56b13816-1b33-4b4d-85b0-fe030e2cb552)

<br>

After the changes is: The ipynb_checkpoints are ignored.

![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/57aaad5b-e8d8-49d5-9266-6da87bae281a)



<br>
<br>
<br>

Test from same repo - https://github.com/OpenSourceBrain/CelegansNeuromechanicalGaitModulation/tree/master/WormSim

![image](https://github.com/OpenSourceBrain/OSBv2/assets/59233227/14c1e73a-76cf-4d9e-a7f0-08efce95069b)

<img width="657" alt="image" src="https://github.com/OpenSourceBrain/OSBv2/assets/59233227/5d29bb49-6b66-4dea-927e-0ab57069e476">
