### PR TITLE
Feat: use more git in github-copy

### DIFF
--- a/applications/workspaces/tasks/github-copy/run.sh
+++ b/applications/workspaces/tasks/github-copy/run.sh
@@ -6,6 +6,8 @@ set -e
 # and append the folder
 export download_path=`echo $shared_directory | cut -d ":" -f 2`/"${folder}"
 
+timestamp="$(date +"%Y%m%d%H%M%S-osbv2")"
+
 mkdir -p "${download_path}"
 cd "${download_path}"
 
@@ -23,7 +25,6 @@ fi
 if [ -z "$paths" ]; then
   echo "Checking out everything"
   git checkout HEAD
-  exit 0
 else
   # Split paths by ## and checkout each path
   IFS='\'
@@ -32,6 +33,20 @@ else
     git checkout HEAD "$path"
   done
 fi
+
+# set username for commit
+git config user.name "OSBv2"
+git config user.email "info@opensourcebrain.org"
+
+# create new branch, commit there
+git checkout -b "$timestamp"
+git commit -m "checked out on osbv2"
+
+# unset username
+git config user.name ""
+git config user.email ""
+
+
 # fix permissions
 chown -R 1000:100 "${download_path}"
 ls -la

--- a/applications/workspaces/tasks/github-copy/run.sh
+++ b/applications/workspaces/tasks/github-copy/run.sh
@@ -5,35 +5,40 @@ set -e
 # remove the pvc from the path (if it has one)
 # and append the folder
 export download_path=`echo $shared_directory | cut -d ":" -f 2`/"${folder}"
+echo "Download path is ${download_path}"
 
 timestamp="$(date +"%Y%m%d%H%M%S-osbv2")"
 
 mkdir -p "${download_path}"
 cd "${download_path}"
 
-echo GitHub copy "$paths" to "$download_path"
+echo "GitHub copy $paths to $download_path"
 ls -la
-echo "Fix permissions"
+echo "Git: fix permissions"
 git config --global --add safe.directory "$download_path"
 # set username for commit
-git config user.name "OSBv2"
-git config user.email "info@opensourcebrain.org"
+gituser=$(git config --list | grep user.name)
+gitusermail=$(git config --list | grep user.email)
 
-#
+
 # do the next command only if download path does not exist (initial clone)
 if [ ! -d "${download_path}/.git" ]; then
-  echo Cloning $branch
+  echo "Git: cloning $branch"
   git clone -n "${url}" --branch $branch "${download_path}"
-  #
+
+  # configure OSB user
+  git config user.name "OSBv2"
+  git config user.email "info@opensourcebrain.org"
+
   # check is paths has a value. In that case, checkout everything
   if [ -z "$paths" ]; then
-      echo "Checking out everything"
+      echo "Git: checking out everything"
       git checkout HEAD
   else
       # Split paths by ## and checkout each path
       IFS='\'
       for path in $paths; do
-          echo "Checking out $path"
+          echo "Git: checking out $path"
           git checkout HEAD "$path"
       done
   fi
@@ -42,31 +47,49 @@ if [ ! -d "${download_path}/.git" ]; then
   git checkout -b "$timestamp"
   git commit -m "osbv2: checked out repository"
 
+  # unset username
+  git config user.name ""
+  git config user.email ""
+
 # on subsequent updates from same repo
 else
-  git commit -a -m "osbv2: saving state at $timestamp"
+  echo "Updating existing repository"
+  # configure OSB user
+  gituser="$(git config user.name)"
+  git config user.name "OSBv2"
+  gitemail="$(git config user.email)"
+  git config user.email "info@opensourcebrain.org"
+
+  # save state, but do not exit if there's nothing to save
+  echo "Git: saving state"
+  git commit -a -m "osbv2: saving state at $timestamp" || true
 
   # do not assume user has left the default remote name as "origin"
-  git remote add $timestamp "${url}"
-  git fetch $timestamp
+  echo "Git: adding remote"
+  git remote add "$timestamp" "${url}"
+  git fetch "$timestamp" "$branch"
 
   if [ -z "$paths" ]; then
-    echo "Checking out everything"
+    echo "Git: checking out everything"
     git checkout $timestamp/$branch -- *
   else
       # Split paths by ## and checkout each path
       IFS='\'
       for path in $paths; do
-          echo "Checking out $path"
-          git checkout $timestamp "$path"
+          echo "Git: checking out $path"
+          git checkout $timestamp/$branch -- "$path"
       done
   fi
   git commit -a -m "osbv2: updated state at $timestamp"
+
+  echo "Git: undoing remote/user"
+  # remove temporary remote
+  git remote remove "$timestamp"
+  # reset user
+  git config user.name "$gituser"
+  git config user.email "$gitemail"
 fi
 
-# unset username
-git config user.name ""
-git config user.email ""
 
 # fix permissions
 chown -R 1000:100 "${download_path}"

--- a/applications/workspaces/tasks/github-copy/run.sh
+++ b/applications/workspaces/tasks/github-copy/run.sh
@@ -15,37 +15,58 @@ echo GitHub copy "$paths" to "$download_path"
 ls -la
 echo "Fix permissions"
 git config --global --add safe.directory "$download_path"
-# do the next command only if download path does not exist
-if [ ! -d "${download_path}/.git" ]; then
-  echo Cloning $branch
-  git clone -n "${url}" --branch $branch "${download_path}"
-fi
-
-# check is paths has a value. In that case, checkout everything
-if [ -z "$paths" ]; then
-  echo "Checking out everything"
-  git checkout HEAD
-else
-  # Split paths by ## and checkout each path
-  IFS='\'
-  for path in $paths; do
-    echo "Checking out $path"
-    git checkout HEAD "$path"
-  done
-fi
-
 # set username for commit
 git config user.name "OSBv2"
 git config user.email "info@opensourcebrain.org"
 
-# create new branch, commit there
-git checkout -b "$timestamp"
-git commit -m "checked out on osbv2"
+#
+# do the next command only if download path does not exist (initial clone)
+if [ ! -d "${download_path}/.git" ]; then
+  echo Cloning $branch
+  git clone -n "${url}" --branch $branch "${download_path}"
+  #
+  # check is paths has a value. In that case, checkout everything
+  if [ -z "$paths" ]; then
+      echo "Checking out everything"
+      git checkout HEAD
+  else
+      # Split paths by ## and checkout each path
+      IFS='\'
+      for path in $paths; do
+          echo "Checking out $path"
+          git checkout HEAD "$path"
+      done
+  fi
+
+  # create new branch, commit there
+  git checkout -b "$timestamp"
+  git commit -m "osbv2: checked out repository"
+
+# on subsequent updates from same repo
+else
+  git commit -a -m "osbv2: saving state at $timestamp"
+
+  # do not assume user has left the default remote name as "origin"
+  git remote add $timestamp "${url}"
+  git fetch $timestamp
+
+  if [ -z "$paths" ]; then
+    echo "Checking out everything"
+    git checkout $timestamp/$branch -- *
+  else
+      # Split paths by ## and checkout each path
+      IFS='\'
+      for path in $paths; do
+          echo "Checking out $path"
+          git checkout $timestamp "$path"
+      done
+  fi
+  git commit -a -m "osbv2: updated state at $timestamp"
+fi
 
 # unset username
 git config user.name ""
 git config user.email ""
-
 
 # fix permissions
 chown -R 1000:100 "${download_path}"


### PR DESCRIPTION
This updates the github-copy task to make it use git more because why not?

- we'll leave the main branches as they are---we'll do things in new branches that'll be local to users: this will make it easier for people to sync and so on
- when updating files later from the same repository, we do the same thing---we first save the state and then make the updates with a new commit. so, no user data will be overwritten here, which is quite important
- added some echo statements, but they can be removed if they'll pollute the logs