### PR TITLE
893 - Limit size of workspace images/thumbnails, otherwise they hide the workspace descriptions 

### DIFF
--- a/applications/osb-portal/src/pages/WorkspacePage.tsx
+++ b/applications/osb-portal/src/pages/WorkspacePage.tsx
@@ -248,7 +248,7 @@ export const WorkspacePage = (props: any) => {
                 </Grid>
                 <Grid
                   item
-                  justifyContent={workspace?.thumbnail ? "center" : "start"}
+                  justifyContent="start"
                   xs={12}
                   sm={6}
                   lg={6.5}
@@ -274,7 +274,7 @@ export const WorkspacePage = (props: any) => {
                         },
                       }}
                     >
-                      <Box className="imageContainer" display="flex">
+                      <Box className="imageContainer" display="flex" justifyContent="center">
                         {workspace?.thumbnail && (
                           <img
                             width={"100%"}
@@ -286,6 +286,12 @@ export const WorkspacePage = (props: any) => {
                             }
                             title={workspace.name}
                             alt={workspace.name}
+                            style={{
+                              width: 'auto',
+                              height: 'auto',
+                              maxWidth: '100%',
+                              maxHeight: '300px'
+                            }}
                           />
                         )}
                       </Box>


### PR DESCRIPTION
Issue #893 
Problem: Limit size of workspace images/thumbnails, otherwise they hide the workspace descriptions 
Solution: 
Apply limit height for image with use of max-height property.

https://github.com/OpenSourceBrain/OSBv2/assets/67194168/381fa094-d3fe-4d1d-8703-22b3dcaa8eb7

