### PR TITLE
826 - Link for "Already have an account? Log In" - only "Log In" is clickable

### DIFF
--- a/applications/accounts/themes/custom/login/login.ftl
+++ b/applications/accounts/themes/custom/login/login.ftl
@@ -5,7 +5,7 @@
             <span>${msg("doLogIn")} </span>
             <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
                 <div id="kc-registration" class="kc-register">
-                    <span>${msg("noAccount")} <a tabindex="6" href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+                    <span><a tabindex="6" href="${url.registrationUrl}">${msg("noAccount")} ${msg("doRegister")}</a></span>
                 </div>
             </#if>
        </div>

--- a/applications/accounts/themes/custom/login/register.ftl
+++ b/applications/accounts/themes/custom/login/register.ftl
@@ -5,7 +5,7 @@
         <span>${msg("registerTitle")}</span>
         <div id="kc-form-options">
             <div class="${properties.kcFormOptionsWrapperClass!}">
-                <span>Already have an account? <a href="${url.loginUrl}">${kcSanitize(msg("Log In"))?no_esc}</a></span>
+                <span><a href="${url.loginUrl}">Already have an account? ${kcSanitize(msg("Log In"))?no_esc}</a></span>
             </div>
         </div>
         </div>


### PR DESCRIPTION
Issue #826 
Problem: Link for "Already have an account? Log In" - only "Log In" is clickable
Solution: 
Put 'Already have an account' and 'New User' messages inside a tag


https://github.com/OpenSourceBrain/OSBv2/assets/67194168/c077ddff-c6aa-4ea6-99b7-428ed7cb90ff

