### PR TITLE
881 - Pagination does not reset when changing between My Repositories and All Repositories

### DIFF
--- a/applications/osb-portal/src/pages/Repositories/RepositoriesPage.tsx
+++ b/applications/osb-portal/src/pages/Repositories/RepositoriesPage.tsx
@@ -157,6 +157,7 @@ export const RepositoriesPage = ({
   const handleTabChange = (event: any, newValue: RepositoriesTab) => {
     setTotal(0);
     setTabValue(newValue);
+    setPage(1)
   };
 
   const changeListView = (type: string) => {


### PR DESCRIPTION
Issue #881 
Problem: Pagination does not reset when changing between My Repositories and All Repositories
Solution: 
Page number is reset to 1 when change tab value


https://github.com/OpenSourceBrain/OSBv2/assets/67194168/47e7dfef-6407-4b56-adaa-198e0df89322


