### PR TITLE
fix(biomodels): replace '+' in file names with spaces

### DIFF
--- a/applications/workspaces/tasks/biomodels-copy/run.sh
+++ b/applications/workspaces/tasks/biomodels-copy/run.sh
@@ -30,7 +30,17 @@ else
         echo "${path}" >> filelist
     done
     echo Biomodels downloading files
-    aria2c --retry-wait=2 --max-tries=5 --input-file=filelist --max-concurrent-downloads=5 --max-connection-per-server=5 --allow-overwrite "true" --auto-file-renaming "false"
+    # Move to temporary directory to rename only the downloaded files.
+    # Otherwise we risk renaming all files, even ones where the user has used
+    # '+' in the file name explicitly
+    tempdir=$(mktemp -d)
+    pushd "${tempdir}"
+        aria2c --retry-wait=2 --max-tries=5 --input-file=filelist --max-concurrent-downloads=5 --max-connection-per-server=5 --allow-overwrite "true" --auto-file-renaming "false"
+        rename -a '+' ' ' *.*
+    popd
+    mv "${tempdir}/*" .
+    # directory should be empty, so rmdir will work
+    rmdir "${tempdir}"
     rm filelist -f
 fi
 


### PR DESCRIPTION
Fixes #943

The Biomodels API returns files with '+' in their names instead of spaces. While this is a good idea, the issue is that the name of the downloaded files are different from what the web interface shows. This is unexpected.

So, we manually rename the files back to the spaced versions after downloading them into a temporary directory. This assumes that:

- no file uses '+' in its file name: they're all only there as replacements for spaces

We must download to a temporary directory because otherwise we'll have to figure out a way of tracking what files were downloaded and only rename them. Otherwise, using the wildcard in `rename` would rename all files in the folder, even ones that weren't downloaded in this session. While it is unlikely that users will use '+' in their own file names, if they do, we don't want to tinker with that.