### PR TITLE
Fix: more biomodels copy fixes

### DIFF
--- a/applications/workspaces/tasks/figshare-copy/run.sh
+++ b/applications/workspaces/tasks/figshare-copy/run.sh
@@ -9,23 +9,25 @@ export download_path=`echo $shared_directory | cut -d ":" -f 2`/"${folder}"
 mkdir -p "${download_path}"
 cd "${download_path}"
 
+filelist=$(mktemp)
+
 # if a file url is passed
 if echo "${url}" | grep -E "https://" 2>&1 > /dev/null
 then
     echo Figshare copy "${url}" to "${download_path}"
-    echo "${url}" > filelist
+    echo "${url}" > "${filelist}"
 else
     # if the article id is passed, download all files
     echo Figshare copy all files of article "${url}" to "${download_path}"
-    curl -X GET "https://api.figshare.com/v2/articles/${url}/files" | tr "}" "\n" | grep -Eo "https://ndownloader.figshare.com/files/[[:digit:]]+" > filelist
+    curl -X GET "https://api.figshare.com/v2/articles/${url}/files" | tr "}" "\n" | grep -Eo "https://ndownloader.figshare.com/files/[[:digit:]]+" > "${filelist}"
 fi
 
 # multiple downloads concurrently, with multiple connections to the server
 # overwrite files if they are downloaded again
-aria2c --retry-wait=2 --max-tries=5 --input-file=filelist --max-concurrent-downloads=5 --max-connection-per-server=5 --allow-overwrite "true" --auto-file-renaming "false"
+aria2c --retry-wait=2 --max-tries=5 --input-file="${filelist}" --max-concurrent-downloads=5 --max-connection-per-server=5 --allow-overwrite "true" --auto-file-renaming "false"
 
 # delete the file list
-rm filelist -f
+rm "${filelist}" -f
 
 # fix permissions
 chown -R 1000:100 "${download_path}"


### PR DESCRIPTION
Correct the path of the file list, and use `mktemp` to ensure there are no file name collisions.